### PR TITLE
feat: add writer `nodepool` attribute to background persistence

### DIFF
--- a/docs/resources/cluster_background_persistence.md
+++ b/docs/resources/cluster_background_persistence.md
@@ -83,6 +83,7 @@ Optional:
 - `metadata_sql_ssl_client_cert_secret` (String) Metadata SQL SSL client cert secret
 - `metadata_sql_ssl_client_key_secret` (String) Metadata SQL SSL client key secret
 - `metadata_sql_uri_secret` (String) Metadata SQL URI secret
+- `nodepool` (String) Nodepool to pin the writer to. On GCP this becomes a GKE node selector plus toleration; on AWS it maps to the Karpenter nodepool. When unset, the writer runs on the default nodepool.
 - `offline_store_inserter_db_type` (String) Offline store inserter DB type
 - `query_table_write_drop_ratio` (String) Query table write drop ratio
 - `request` (Attributes) Resource requests (see [below for nested schema](#nestedatt--writers--request))

--- a/docs/resources/unmanaged_cluster_background_persistence.md
+++ b/docs/resources/unmanaged_cluster_background_persistence.md
@@ -65,6 +65,7 @@ Optional:
 - `metadata_sql_ssl_client_cert_secret` (String) Metadata SQL SSL client cert secret
 - `metadata_sql_ssl_client_key_secret` (String) Metadata SQL SSL client key secret
 - `metadata_sql_uri_secret` (String) Metadata SQL URI secret
+- `nodepool` (String) Nodepool to pin the writer to. On GCP this becomes a GKE node selector plus toleration; on AWS it maps to the Karpenter nodepool. When unset, the writer runs on the default nodepool.
 - `offline_store_inserter_db_type` (String) Offline store inserter DB type
 - `query_table_write_drop_ratio` (String) Query table write drop ratio
 - `request` (Attributes) Resource requests (see [below for nested schema](#nestedatt--writers--request))

--- a/internal/provider/background_persistence_writers.go
+++ b/internal/provider/background_persistence_writers.go
@@ -142,6 +142,10 @@ var bgpWritersNestedAttrs = map[string]schema.Attribute{
 		Optional:            true,
 		ElementType:         types.StringType,
 	},
+	"nodepool": schema.StringAttribute{
+		MarkdownDescription: "Nodepool to pin the writer to. On GCP this becomes a GKE node selector plus toleration; on AWS it maps to the Karpenter nodepool. When unset, the writer runs on the default nodepool.",
+		Optional:            true,
+	},
 }
 
 var bgpWritersSchemaAttribute = schema.ListNestedAttribute{
@@ -194,6 +198,7 @@ var bgpWriterObjectType = types.ObjectType{
 		"storage_cache_prefix":                types.StringType,
 		"results_writer_skip_producing_feature_metrics": types.BoolType,
 		"query_table_write_drop_ratio":                  types.StringType,
+		"nodepool":                                      types.StringType,
 		"additional_env_vars":                           types.MapType{ElemType: types.StringType},
 	},
 }
@@ -242,6 +247,9 @@ func bgpWritersTFToProto(ctx context.Context, writersList types.List) ([]*server
 		}
 		if !writer.QueryTableWriteDropRatio.IsNull() {
 			protoWriter.QueryTableWriteDropRatio = writer.QueryTableWriteDropRatio.ValueString()
+		}
+		if !writer.Nodepool.IsNull() {
+			protoWriter.Nodepool = writer.Nodepool.ValueString()
 		}
 		if !writer.GkeSpot.IsNull() {
 			val := writer.GkeSpot.ValueBool()
@@ -394,6 +402,11 @@ func bgpWritersProtoToTF(ctx context.Context, protoWriters []*serverv1.Backgroun
 			tfWriter.QueryTableWriteDropRatio = types.StringValue(protoWriter.QueryTableWriteDropRatio)
 		} else {
 			tfWriter.QueryTableWriteDropRatio = types.StringNull()
+		}
+		if protoWriter.Nodepool != "" {
+			tfWriter.Nodepool = types.StringValue(protoWriter.Nodepool)
+		} else {
+			tfWriter.Nodepool = types.StringNull()
 		}
 		if protoWriter.KafkaConsumerGroupOverride != "" {
 			tfWriter.KafkaConsumerGroupOverride = types.StringValue(protoWriter.KafkaConsumerGroupOverride)

--- a/internal/provider/background_persistence_writers_test.go
+++ b/internal/provider/background_persistence_writers_test.go
@@ -170,6 +170,70 @@ func TestBgpWritersProtoToTF_ExplicitServerValues(t *testing.T) {
 	assert.Equal(t, types.BoolValue(false), m.ResultsWriterSkipProducingFeatureMetrics)
 }
 
+// TestBgpWritersProtoToTF_NodepoolOmitted: server omits nodepool (empty string)
+// -> model decodes to null so an HCL omission produces no perpetual diff.
+func TestBgpWritersProtoToTF_NodepoolOmitted(t *testing.T) {
+	t.Parallel()
+	w := &serverv1.BackgroundPersistenceWriterSpecs{
+		Name:              "offline-writer",
+		BusSubscriberType: "OFFLINE_WRITER",
+	}
+	m := decodeSingleWriter(t, w)
+	assert.Equal(t, types.StringNull(), m.Nodepool)
+}
+
+// TestBgpWritersProtoToTF_NodepoolExplicit: server returns a nodepool ->
+// model carries it. This is the INF-1286 phantom-drift guard: Read must
+// populate nodepool from the server spec.
+func TestBgpWritersProtoToTF_NodepoolExplicit(t *testing.T) {
+	t.Parallel()
+	w := &serverv1.BackgroundPersistenceWriterSpecs{
+		Name:              "offline-writer",
+		BusSubscriberType: "OFFLINE_WRITER",
+		Nodepool:          "offline-writer-spot-8",
+	}
+	m := decodeSingleWriter(t, w)
+	assert.Equal(t, types.StringValue("offline-writer-spot-8"), m.Nodepool)
+}
+
+// TestBgpWritersTFToProto_NodepoolNullNoChurn: a null nodepool encodes to an
+// empty proto string (left unset), matching every other optional string field
+// so an omitted attribute never produces a write/churn.
+func TestBgpWritersTFToProto_NodepoolNullNoChurn(t *testing.T) {
+	t.Parallel()
+	w := &serverv1.BackgroundPersistenceWriterSpecs{
+		Name:              "offline-writer",
+		BusSubscriberType: "OFFLINE_WRITER",
+	}
+	m := decodeSingleWriter(t, w)
+	require.Equal(t, types.StringNull(), m.Nodepool)
+
+	ctx := context.Background()
+	list, diags := bgpWritersProtoToTF(ctx, []*serverv1.BackgroundPersistenceWriterSpecs{w})
+	require.False(t, diags.HasError())
+	out, diags := bgpWritersTFToProto(ctx, list)
+	require.False(t, diags.HasError())
+	require.Len(t, out, 1)
+	assert.Equal(t, "", out[0].Nodepool)
+}
+
+// TestWriterNodepoolRoundTrip: proto -> TF -> proto preserves nodepool.
+func TestWriterNodepoolRoundTrip(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	original := &serverv1.BackgroundPersistenceWriterSpecs{
+		Name:              "offline-writer",
+		BusSubscriberType: "OFFLINE_WRITER",
+		Nodepool:          "offline-writer-spot-8",
+	}
+	list, diags := bgpWritersProtoToTF(ctx, []*serverv1.BackgroundPersistenceWriterSpecs{original})
+	require.False(t, diags.HasError(), "decode diagnostics: %v", diags)
+	out, diags := bgpWritersTFToProto(ctx, list)
+	require.False(t, diags.HasError(), "encode diagnostics: %v", diags)
+	require.Len(t, out, 1)
+	assert.Equal(t, original.Nodepool, out[0].Nodepool)
+}
+
 // TestBgpWritersProtoToTF_ProtoRoundTrip converts proto -> TF -> proto and asserts
 // semantic equality for a fully-populated writer. Guards the decoder from drifting
 // away from the encoder.
@@ -195,6 +259,7 @@ func TestBgpWritersProtoToTF_ProtoRoundTrip(t *testing.T) {
 		MetadataSqlSslCaCertSecret:               "secret-ca",
 		MetadataSqlSslClientCertSecret:           "secret-client-cert",
 		MetadataSqlSslClientKeySecret:            "secret-client-key",
+		Nodepool:                                 "offline-writer-spot-8",
 		Request:                                  &serverv1.KubeResourceConfig{Cpu: "500m", Memory: "1Gi"},
 		Limit:                                    &serverv1.KubeResourceConfig{Cpu: "1", Memory: "2Gi"},
 		HpaSpecs: &serverv1.BackgroundPersistenceWriterHpaSpecs{
@@ -232,6 +297,7 @@ func TestBgpWritersProtoToTF_ProtoRoundTrip(t *testing.T) {
 	assert.Equal(t, original.MetadataSqlSslCaCertSecret, roundTripped.MetadataSqlSslCaCertSecret)
 	assert.Equal(t, original.MetadataSqlSslClientCertSecret, roundTripped.MetadataSqlSslClientCertSecret)
 	assert.Equal(t, original.MetadataSqlSslClientKeySecret, roundTripped.MetadataSqlSslClientKeySecret)
+	assert.Equal(t, original.Nodepool, roundTripped.Nodepool)
 	assert.Equal(t, original.Request.Cpu, roundTripped.Request.Cpu)
 	assert.Equal(t, original.Request.Memory, roundTripped.Request.Memory)
 	assert.Equal(t, original.Limit.Cpu, roundTripped.Limit.Cpu)

--- a/internal/provider/cluster_background_persistence_resource.go
+++ b/internal/provider/cluster_background_persistence_resource.go
@@ -67,6 +67,7 @@ type BackgroundPersistenceWriterModel struct {
 	StorageCachePrefix                       types.String                         `tfsdk:"storage_cache_prefix"`
 	ResultsWriterSkipProducingFeatureMetrics types.Bool                           `tfsdk:"results_writer_skip_producing_feature_metrics"`
 	QueryTableWriteDropRatio                 types.String                         `tfsdk:"query_table_write_drop_ratio"`
+	Nodepool                                 types.String                         `tfsdk:"nodepool"`
 	AdditionalEnvVars                        types.Map                            `tfsdk:"additional_env_vars"`
 }
 


### PR DESCRIPTION
## Summary

Exposes `BackgroundPersistenceWriterSpecs.nodepool` (proto field 24) as an Optional string attribute on the `writers` nested schema, shared by both `chalk_cluster_background_persistence` and `chalk_unmanaged_cluster_background_persistence`. This lets Terraform-managed writer specs pin a writer to a specific nodepool — on GCP it becomes a GKE node selector + toleration; on AWS it maps to the Karpenter nodepool. When unset, the writer runs on the default nodepool.

Motivation: melio's 6 writers all pin `offline-writer-spot-8`, which can't be expressed in TF-managed specs today (part of INF-1447, moving melio background persistence to API-server-managed).

## Notes

- **No dependency bump.** The field already exists in the pinned `chalk-go/gen v1.2.241` as a plain `string` (field 24).
- Wired through the two shared conversion funcs in `background_persistence_writers.go`, which back both resources and all Read/refresh paths — so `Read` populates `nodepool` from the server spec. This is the **INF-1286 phantom-drift guard**: without it, every plan on an imported/refreshed resource would show spurious drift.
- Follows the established sibling plain-string convention (`image_override`, `version`, …): empty proto string ⇄ `StringNull()`, so an omitted attribute never churns.
- Sibling attrs `node_selector` / `instance_type` deferred — not present on the proto at v1.2.241.

## Tests

- `TestWriterNodepoolRoundTrip` — proto → TF → proto preserves nodepool
- `TestBgpWritersProtoToTF_NodepoolExplicit` — Read populates from server spec
- `TestBgpWritersProtoToTF_NodepoolOmitted` — empty server value → null
- `TestBgpWritersTFToProto_NodepoolNullNoChurn` — null → empty proto (no write)
- nodepool added to the existing full round-trip test

Verification:
- `TF_ACC=1 go test ./internal/provider/` → green (incl. acceptance, ~16s)
- `gofmt -l` / `go vet` / `go tool staticcheck` → clean
- `make docs` → regenerated for both resources

Closes INF-1468 (sub-issue of INF-1447).