### PR TITLE
Drop Sensitive from *_store_secret fields (they're secret-manager locators, not secrets)

### DIFF
--- a/docs/data-sources/environment.md
+++ b/docs/data-sources/environment.md
@@ -53,7 +53,7 @@ data "chalk_environment" "example" {
 - `engine_docker_registry_path` (String) Engine Docker registry path
 - `engine_kube_cluster_name` (String) Engine Kubernetes cluster name
 - `environment_buckets` (Object) Environment object storage buckets (see [below for nested schema](#nestedatt--environment_buckets))
-- `feature_store_secret` (String) Feature store secret
+- `feature_store_secret` (String) Feature store secret reference
 - `grpc_engine_url` (String) gRPC engine URL
 - `is_sandbox` (Boolean) Is sandbox environment
 - `kube_cluster_mode` (String) Kubernetes cluster mode
@@ -64,10 +64,10 @@ data "chalk_environment" "example" {
 - `metadata_server_metrics_store_secret` (String) Metadata server metrics store secret
 - `metrics_bus_topic` (String) Metrics bus topic
 - `name` (String) Environment name
-- `offline_store_secret` (String) Offline store secret
+- `offline_store_secret` (String) Offline store secret reference
 - `online_persistence_mode` (String) Online persistence mode
 - `online_store_kind` (String) Online store kind for the environment
-- `online_store_secret` (String) Online store secret
+- `online_store_secret` (String) Online store secret reference
 - `pinned_base_image` (String) Pinned base image
 - `postgres_secret` (String) Postgres secret
 - `private_pip_repositories` (String) Private pip repositories

--- a/docs/resources/environment.md
+++ b/docs/resources/environment.md
@@ -39,7 +39,7 @@ Chalk environment resource
 - `kube_service_account_name` (String) Kubernetes service account name
 - `managed` (Boolean) Whether to bootstrap cloud infrastructure
 - `online_store_kind` (String) Online store kind
-- `online_store_secret` (String, Sensitive) Online store secret
+- `online_store_secret` (String) Online store secret
 - `private_pip_repositories` (String) Private pip repositories
 - `service_url` (String) Service URL
 - `source_bundle_bucket` (String) Source bundle bucket

--- a/docs/resources/environment.md
+++ b/docs/resources/environment.md
@@ -33,13 +33,13 @@ Chalk environment resource
 - `branch_url` (String) Branch URL
 - `engine_docker_registry_path` (String) Engine Docker registry path
 - `environment_buckets` (Attributes) Environment object storage configuration (see [below for nested schema](#nestedatt--environment_buckets))
-- `feature_store_secret` (String) Feature store secret
+- `feature_store_secret` (String) Feature store secret reference
 - `kube_cluster_id` (String) Kubernetes cluster ID
 - `kube_job_namespace` (String) Kubernetes job namespace
 - `kube_service_account_name` (String) Kubernetes service account name
 - `managed` (Boolean) Whether to bootstrap cloud infrastructure
 - `online_store_kind` (String) Online store kind
-- `online_store_secret` (String) Online store secret
+- `online_store_secret` (String) Online store secret reference
 - `private_pip_repositories` (String) Private pip repositories
 - `service_url` (String) Service URL
 - `source_bundle_bucket` (String) Source bundle bucket

--- a/docs/resources/environment.md
+++ b/docs/resources/environment.md
@@ -33,7 +33,7 @@ Chalk environment resource
 - `branch_url` (String) Branch URL
 - `engine_docker_registry_path` (String) Engine Docker registry path
 - `environment_buckets` (Attributes) Environment object storage configuration (see [below for nested schema](#nestedatt--environment_buckets))
-- `feature_store_secret` (String, Sensitive) Feature store secret
+- `feature_store_secret` (String) Feature store secret
 - `kube_cluster_id` (String) Kubernetes cluster ID
 - `kube_job_namespace` (String) Kubernetes job namespace
 - `kube_service_account_name` (String) Kubernetes service account name

--- a/docs/resources/managed_environment.md
+++ b/docs/resources/managed_environment.md
@@ -34,7 +34,7 @@ Chalk managed environment resource
 - `id` (String) Environment identifier; server-generated (immutable)
 - `kube_job_namespace` (String) Kubernetes job namespace (immutable; auto-assigned by server if not provided)
 - `online_store_kind` (String) Online store kind
-- `online_store_secret` (String) Online store secret
+- `online_store_secret` (String) Online store secret reference
 - `pinned_base_image` (String) Pinned base image for deployments
 - `private_pip_repositories` (String) Private pip repositories
 - `service_url` (String) Service URL (set by server if not provided)

--- a/docs/resources/managed_environment.md
+++ b/docs/resources/managed_environment.md
@@ -34,7 +34,7 @@ Chalk managed environment resource
 - `id` (String) Environment identifier; server-generated (immutable)
 - `kube_job_namespace` (String) Kubernetes job namespace (immutable; auto-assigned by server if not provided)
 - `online_store_kind` (String) Online store kind
-- `online_store_secret` (String, Sensitive) Online store secret
+- `online_store_secret` (String) Online store secret
 - `pinned_base_image` (String) Pinned base image for deployments
 - `private_pip_repositories` (String) Private pip repositories
 - `service_url` (String) Service URL (set by server if not provided)

--- a/docs/resources/unmanaged_environment.md
+++ b/docs/resources/unmanaged_environment.md
@@ -36,7 +36,7 @@ Chalk unmanaged environment resource
 - `kube_cluster_mode` (String) Kubernetes cluster mode (unmanaged environments only)
 - `kube_service_account_name` (String) Kubernetes service account name
 - `online_store_kind` (String) Online store kind
-- `online_store_secret` (String, Sensitive) Online store secret
+- `online_store_secret` (String) Online store secret
 - `pinned_base_image` (String) Pinned base image for deployments
 - `private_pip_repositories` (String) Private pip repositories
 - `service_url` (String) Service URL (set by server if not provided)

--- a/docs/resources/unmanaged_environment.md
+++ b/docs/resources/unmanaged_environment.md
@@ -36,7 +36,7 @@ Chalk unmanaged environment resource
 - `kube_cluster_mode` (String) Kubernetes cluster mode (unmanaged environments only)
 - `kube_service_account_name` (String) Kubernetes service account name
 - `online_store_kind` (String) Online store kind
-- `online_store_secret` (String) Online store secret
+- `online_store_secret` (String) Online store secret reference
 - `pinned_base_image` (String) Pinned base image for deployments
 - `private_pip_repositories` (String) Private pip repositories
 - `service_url` (String) Service URL (set by server if not provided)

--- a/internal/provider/environment_data_source.go
+++ b/internal/provider/environment_data_source.go
@@ -126,15 +126,15 @@ func (d *EnvironmentDataSource) Schema(ctx context.Context, req datasource.Schem
 				Computed:            true,
 			},
 			"offline_store_secret": schema.StringAttribute{
-				MarkdownDescription: "Offline store secret",
+				MarkdownDescription: "Offline store secret reference",
 				Computed:            true,
 			},
 			"online_store_secret": schema.StringAttribute{
-				MarkdownDescription: "Online store secret",
+				MarkdownDescription: "Online store secret reference",
 				Computed:            true,
 			},
 			"feature_store_secret": schema.StringAttribute{
-				MarkdownDescription: "Feature store secret",
+				MarkdownDescription: "Feature store secret reference",
 				Computed:            true,
 			},
 			"postgres_secret": schema.StringAttribute{

--- a/internal/provider/environment_resource.go
+++ b/internal/provider/environment_resource.go
@@ -131,7 +131,6 @@ func (r *EnvironmentResource) Schema(ctx context.Context, req resource.SchemaReq
 			"feature_store_secret": schema.StringAttribute{
 				MarkdownDescription: "Feature store secret",
 				Optional:            true,
-				Sensitive:           true,
 			},
 			"private_pip_repositories": schema.StringAttribute{
 				MarkdownDescription: "Private pip repositories",

--- a/internal/provider/environment_resource.go
+++ b/internal/provider/environment_resource.go
@@ -123,7 +123,6 @@ func (r *EnvironmentResource) Schema(ctx context.Context, req resource.SchemaReq
 			"online_store_secret": schema.StringAttribute{
 				MarkdownDescription: "Online store secret",
 				Optional:            true,
-				Sensitive:           true,
 			},
 			"online_store_kind": schema.StringAttribute{
 				MarkdownDescription: "Online store kind",

--- a/internal/provider/environment_resource.go
+++ b/internal/provider/environment_resource.go
@@ -121,7 +121,7 @@ func (r *EnvironmentResource) Schema(ctx context.Context, req resource.SchemaReq
 				},
 			},
 			"online_store_secret": schema.StringAttribute{
-				MarkdownDescription: "Online store secret",
+				MarkdownDescription: "Online store secret reference",
 				Optional:            true,
 			},
 			"online_store_kind": schema.StringAttribute{
@@ -129,7 +129,7 @@ func (r *EnvironmentResource) Schema(ctx context.Context, req resource.SchemaReq
 				Optional:            true,
 			},
 			"feature_store_secret": schema.StringAttribute{
-				MarkdownDescription: "Feature store secret",
+				MarkdownDescription: "Feature store secret reference",
 				Optional:            true,
 			},
 			"private_pip_repositories": schema.StringAttribute{

--- a/internal/provider/environment_resource_base.go
+++ b/internal/provider/environment_resource_base.go
@@ -95,7 +95,7 @@ func commonEnvironmentSchemaAttributes(kubeJobNamespace schema.Attribute) map[st
 			Optional:            true,
 		},
 		"online_store_secret": schema.StringAttribute{
-			MarkdownDescription: "Online store secret",
+			MarkdownDescription: "Online store secret reference",
 			Optional:            true,
 		},
 		"additional_env_vars": schema.MapAttribute{

--- a/internal/provider/environment_resource_base.go
+++ b/internal/provider/environment_resource_base.go
@@ -97,7 +97,6 @@ func commonEnvironmentSchemaAttributes(kubeJobNamespace schema.Attribute) map[st
 		"online_store_secret": schema.StringAttribute{
 			MarkdownDescription: "Online store secret",
 			Optional:            true,
-			Sensitive:           true,
 		},
 		"additional_env_vars": schema.MapAttribute{
 			MarkdownDescription: "Additional environment variables",


### PR DESCRIPTION
## What this is

The `*_store_secret` fields do not hold secret values — each is a **placeholder /
reference the engine uses to fetch the real credential from a secret manager**.
So marking them `Sensitive: true` was incorrect: they're plain configuration
locators, not sensitive material.

This PR covers `online_store_secret` and `feature_store_secret`.

## Why it matters in practice

Because it was flagged `Sensitive`, `terraform plan -generate-config-out`
**omitted** `online_store_secret` when importing an existing environment,
producing a permanent diff on every plan:

```
~ online_store_secret = (sensitive value) -> null
```

That blocks an imported environment from reaching a clean `0 to change` plan
unless you add a `lifecycle { ignore_changes = [online_store_secret] }`
workaround. (Surfaced while validating import of an existing customer
environment.)

## Change

- Remove `Sensitive: true` from `online_store_secret`:
  - `environment_resource_base.go` (`chalk_managed_environment` + `chalk_unmanaged_environment`)
  - `environment_resource.go` (standalone `chalk_environment`)
- Remove `Sensitive: true` from `feature_store_secret` (`environment_resource.go` — the only resource that defines it).
- Update the affected generated docs.

The `environment` data source already exposed these as non-sensitive, so this
makes the resources consistent with it.

## Please confirm

I extended this to `feature_store_secret` on the assumption it's the same kind of
secret-manager locator as `online_store_secret`. If `feature_store_secret` (or
`offline_store_secret`) is ever a real secret value, say so and I'll drop it from
this PR.

## Verification

- `go build ./...` ✅
- pre-commit (`go vet`, `gofmt`, `staticcheck`) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)