### PR TITLE
Normalize private_pip_repositories JSON to stop spurious whitespace diffs

### DIFF
--- a/internal/provider/environment_resource_base.go
+++ b/internal/provider/environment_resource_base.go
@@ -32,7 +32,7 @@ type BaseEnvironmentModel struct {
 	AdditionalEnvVars        types.Map            `tfsdk:"additional_env_vars"`
 	EnvironmentBuckets       types.Object         `tfsdk:"environment_buckets"`
 	SpecsConfigJson          jsontypes.Normalized `tfsdk:"specs_config_json"`
-	PrivatePipRepositories   types.String         `tfsdk:"private_pip_repositories"`
+	PrivatePipRepositories   jsontypes.Normalized `tfsdk:"private_pip_repositories"`
 	PinnedBaseImage          types.String         `tfsdk:"pinned_base_image"`
 	DefaultBuildProfile      types.String         `tfsdk:"default_build_profile"`
 	CustomerMetadata         jsontypes.Normalized `tfsdk:"customer_metadata"`
@@ -136,6 +136,7 @@ func commonEnvironmentSchemaAttributes(kubeJobNamespace schema.Attribute) map[st
 		},
 		"private_pip_repositories": schema.StringAttribute{
 			MarkdownDescription: "Private pip repositories",
+			CustomType:          jsontypes.NormalizedType{},
 			Optional:            true,
 		},
 		"pinned_base_image": schema.StringAttribute{
@@ -270,7 +271,11 @@ func baseUpdateStateFromEnvironment(data *BaseEnvironmentModel, e *serverv1.Envi
 	data.ServiceUrl = types.StringPointerValue(e.ServiceUrl)
 	data.OnlineStoreKind = types.StringPointerValue(e.OnlineStoreKind)
 	data.OnlineStoreSecret = types.StringPointerValue(e.OnlineStoreSecret)
-	data.PrivatePipRepositories = types.StringPointerValue(e.PrivatePipRepositories)
+	if e.PrivatePipRepositories != nil {
+		data.PrivatePipRepositories = jsontypes.NewNormalizedValue(*e.PrivatePipRepositories)
+	} else {
+		data.PrivatePipRepositories = jsontypes.NewNormalizedNull()
+	}
 	data.PinnedBaseImage = types.StringPointerValue(e.PinnedBaseImage)
 	if e.DefaultBuildProfile != nil && *e.DefaultBuildProfile != serverv1.DeploymentBuildProfile_DEPLOYMENT_BUILD_PROFILE_UNSPECIFIED {
 		data.DefaultBuildProfile = types.StringValue(e.DefaultBuildProfile.String())

--- a/internal/provider/unmanaged_environment_resource_test.go
+++ b/internal/provider/unmanaged_environment_resource_test.go
@@ -144,7 +144,7 @@ resource "chalk_unmanaged_environment" "test" {
   project_id              = "test-project"
   kube_cluster_id         = "test-cluster-id"
   kube_job_namespace      = "test-namespace"
-  private_pip_repositories = "https://pypi.example.com"
+  private_pip_repositories = "{\"index-url\":\"https://pypi.example.com\"}"
 }
 `,
 			},
@@ -155,7 +155,7 @@ resource "chalk_unmanaged_environment" "test" {
   project_id              = "test-project"
   kube_cluster_id         = "test-cluster-id"
   kube_job_namespace      = "test-namespace"
-  private_pip_repositories = "https://pypi2.example.com"
+  private_pip_repositories = "{\"index-url\":\"https://pypi2.example.com\"}"
 }
 `,
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -168,7 +168,7 @@ resource "chalk_unmanaged_environment" "test" {
 						assert.Equal(t, []string{"private_pip_repositories"}, req.UpdateMask.Paths,
 							"Expected only 'private_pip_repositories' in field mask")
 						require.NotNil(t, req.Environment.PrivatePipRepositories)
-						assert.Equal(t, "https://pypi2.example.com", *req.Environment.PrivatePipRepositories)
+						assert.Equal(t, "{\"index-url\":\"https://pypi2.example.com\"}", *req.Environment.PrivatePipRepositories)
 
 						return nil
 					},


### PR DESCRIPTION
## Problem

`private_pip_repositories` holds a JSON string, but it was declared as a plain
`types.String`, so Terraform compares it **byte-for-byte**. The server
re-serializes the JSON with different whitespace than `jsonencode` produces, so
every `plan` shows a perpetual no-op "update" on the field:

```
~ private_pip_repositories = jsonencode( # whitespace changes
      { ... }
  )
```

On an imported environment this prevents ever reaching a clean `0 to change`
plan without a `lifecycle { ignore_changes = [private_pip_repositories] }`
workaround. (Found alongside the `online_store_secret` issue in #79 while
validating import of an existing customer environment.)

## Fix

Give `private_pip_repositories` the same `jsontypes.Normalized` custom type that
`specs_config_json` and `customer_metadata` **already use in this same file**, so
comparison is semantic (JSON value equality — insensitive to whitespace and key
ordering). Three changes, mirroring the existing fields:

- model field: `types.String` → `jsontypes.Normalized`
- schema: add `CustomType: jsontypes.NormalizedType{}`
- read path: `NewNormalizedValue` / `NewNormalizedNull`

No doc change needed — `jsontypes.Normalized` renders as `(String)`, same as
`specs_config_json` already does.

## Scope

This covers the base schema shared by `chalk_managed_environment` and
`chalk_unmanaged_environment`. The standalone `chalk_environment` resource stores
*all* its JSON fields (including `specs_config_json`) as plain strings and has the
same class of problem more broadly — left for a separate change to keep this one
focused.

## Verification

- `go build ./...` ✅
- `go vet ./...` ✅
- pre-commit (`go vet`, `gofmt`, `staticcheck`) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)