### PR TITLE
Make JSON env fields Optional+Computed so imported envs reach a clean plan

### DIFF
--- a/internal/provider/environment_resource_base.go
+++ b/internal/provider/environment_resource_base.go
@@ -137,6 +137,7 @@ func commonEnvironmentSchemaAttributes(kubeJobNamespace schema.Attribute) map[st
 			MarkdownDescription: "Private pip repositories",
 			CustomType:          jsontypes.NormalizedType{},
 			Optional:            true,
+			Computed:            true,
 		},
 		"pinned_base_image": schema.StringAttribute{
 			MarkdownDescription: "Pinned base image for deployments",
@@ -157,6 +158,7 @@ func commonEnvironmentSchemaAttributes(kubeJobNamespace schema.Attribute) map[st
 			MarkdownDescription: "Customer metadata as a JSON object",
 			CustomType:          jsontypes.NormalizedType{},
 			Optional:            true,
+			Computed:            true,
 		},
 	}
 }


### PR DESCRIPTION
## Problem

After #80 made `private_pip_repositories` a `jsontypes.Normalized` type, importing an existing environment **still** shows a perpetual diff on a plain `terraform plan`:

```
~ private_pip_repositories = jsonencode( # whitespace changes
    { ... }
  )
```

while `specs_config_json` (same custom type) is clean.

## Root cause

Two facts combine:

1. **Semantic equality is not applied during plan.** In terraform-plugin-framework v1.14.1, `SchemaSemanticEquality` is invoked only from `server_createresource.go`, `server_updateresource.go`, `server_readresource.go`, and `server_readdatasource.go` — **not** from `server_planresourcechange.go`. So `jsontypes.Normalized` suppresses drift on Read/Create/Update, but not in the plan comparison itself.
2. **`-generate-config-out` omits Computed attributes.** `specs_config_json` is `Optional + Computed`, so the generator never writes it to the generated config → there's no config value to diff against → clean. `private_pip_repositories` and `customer_metadata` were `Optional`-only, so they get written as `jsonencode(...)` and compared byte-wise against the engine's raw JSON → whitespace diff.

So #80 was necessary but not sufficient — the missing piece is `Computed`.

## Fix

Make `private_pip_repositories` and `customer_metadata` `Optional + Computed`, matching `specs_config_json`:
- `-generate-config-out` omits them → imported environments reach `0 to change`.
- Still user-manageable: set them explicitly in config to manage; omit to keep the server value (same workflow as `specs_config_json`).
- The `jsontypes.Normalized` type (from #80) keeps refreshes of managed environments drift-free.

## Scope / notes

- Base schema shared by `chalk_managed_environment` and `chalk_unmanaged_environment`. The standalone `chalk_environment` resource stores these as plain strings and has the same class of issue more broadly (noted in #80).
- Docs unchanged: `Optional + Computed` still renders under "Optional".

## Verification

- `go build ./...` ✅
- `go vet ./...` ✅
- pre-commit (`go vet`, `gofmt`, `staticcheck`) ✅
- Acceptance tests (apply against the mock server) not run locally — please confirm in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)