### PR TITLE
Revert "fix(background_persistence): decode empty writer limit/request as null

### DIFF
--- a/internal/provider/background_persistence_writers.go
+++ b/internal/provider/background_persistence_writers.go
@@ -337,41 +337,6 @@ func bgpWritersTFToProto(ctx context.Context, writersList types.List) ([]*server
 	return protoWriters, diags
 }
 
-// kubeResourceConfigProtoToTF maps a proto KubeResourceConfig to its TF model.
-// A nil proto, or a non-nil proto with every field empty, maps to a nil model
-// (null in state). The server returns a non-nil empty KubeResourceConfig{} for
-// request/limit that the user never set (deployment-time defaults are applied to
-// a clone, but an empty object can still be persisted); decoding that as an empty
-// but non-nil {} would never equal the config's null and would cause a permanent
-// "{} -> null" plan diff. Collapsing all-empty to null keeps the round-trip clean.
-func kubeResourceConfigProtoToTF(c *serverv1.KubeResourceConfig) *KubeResourceConfigModel {
-	if c == nil {
-		return nil
-	}
-	if c.Cpu == "" && c.Memory == "" && c.EphemeralStorage == "" && c.Storage == "" {
-		return nil
-	}
-	m := &KubeResourceConfigModel{
-		CPU:              types.StringNull(),
-		Memory:           types.StringNull(),
-		EphemeralStorage: types.StringNull(),
-		Storage:          types.StringNull(),
-	}
-	if c.Cpu != "" {
-		m.CPU = types.StringValue(c.Cpu)
-	}
-	if c.Memory != "" {
-		m.Memory = types.StringValue(c.Memory)
-	}
-	if c.EphemeralStorage != "" {
-		m.EphemeralStorage = types.StringValue(c.EphemeralStorage)
-	}
-	if c.Storage != "" {
-		m.Storage = types.StringValue(c.Storage)
-	}
-	return m
-}
-
 // bgpWritersProtoToTF converts a proto writers slice to a TF list.
 func bgpWritersProtoToTF(ctx context.Context, protoWriters []*serverv1.BackgroundPersistenceWriterSpecs) (types.List, diag.Diagnostics) {
 	if len(protoWriters) == 0 {
@@ -503,8 +468,52 @@ func bgpWritersProtoToTF(ctx context.Context, protoWriters []*serverv1.Backgroun
 			}
 		}
 
-		tfWriter.Request = kubeResourceConfigProtoToTF(protoWriter.Request)
-		tfWriter.Limit = kubeResourceConfigProtoToTF(protoWriter.Limit)
+		if protoWriter.Request != nil {
+			tfWriter.Request = &KubeResourceConfigModel{}
+			if protoWriter.Request.Cpu != "" {
+				tfWriter.Request.CPU = types.StringValue(protoWriter.Request.Cpu)
+			} else {
+				tfWriter.Request.CPU = types.StringNull()
+			}
+			if protoWriter.Request.Memory != "" {
+				tfWriter.Request.Memory = types.StringValue(protoWriter.Request.Memory)
+			} else {
+				tfWriter.Request.Memory = types.StringNull()
+			}
+			if protoWriter.Request.EphemeralStorage != "" {
+				tfWriter.Request.EphemeralStorage = types.StringValue(protoWriter.Request.EphemeralStorage)
+			} else {
+				tfWriter.Request.EphemeralStorage = types.StringNull()
+			}
+			if protoWriter.Request.Storage != "" {
+				tfWriter.Request.Storage = types.StringValue(protoWriter.Request.Storage)
+			} else {
+				tfWriter.Request.Storage = types.StringNull()
+			}
+		}
+		if protoWriter.Limit != nil {
+			tfWriter.Limit = &KubeResourceConfigModel{}
+			if protoWriter.Limit.Cpu != "" {
+				tfWriter.Limit.CPU = types.StringValue(protoWriter.Limit.Cpu)
+			} else {
+				tfWriter.Limit.CPU = types.StringNull()
+			}
+			if protoWriter.Limit.Memory != "" {
+				tfWriter.Limit.Memory = types.StringValue(protoWriter.Limit.Memory)
+			} else {
+				tfWriter.Limit.Memory = types.StringNull()
+			}
+			if protoWriter.Limit.EphemeralStorage != "" {
+				tfWriter.Limit.EphemeralStorage = types.StringValue(protoWriter.Limit.EphemeralStorage)
+			} else {
+				tfWriter.Limit.EphemeralStorage = types.StringNull()
+			}
+			if protoWriter.Limit.Storage != "" {
+				tfWriter.Limit.Storage = types.StringValue(protoWriter.Limit.Storage)
+			} else {
+				tfWriter.Limit.Storage = types.StringNull()
+			}
+		}
 
 		tfWriters = append(tfWriters, tfWriter)
 	}

--- a/internal/provider/background_persistence_writers_test.go
+++ b/internal/provider/background_persistence_writers_test.go
@@ -234,45 +234,6 @@ func TestWriterNodepoolRoundTrip(t *testing.T) {
 	assert.Equal(t, original.Nodepool, out[0].Nodepool)
 }
 
-// TestBgpWritersProtoToTF_EmptyLimitMapsToNull is the regression guard for the
-// "limit = {} -> null" perpetual plan diff: the server returns a non-nil but
-// all-empty KubeResourceConfig{} for limit/request the user never set. Decoding
-// that as a non-nil empty {} would never equal the config's null. The decoder
-// must collapse an all-empty object to nil (null in state).
-func TestBgpWritersProtoToTF_EmptyLimitMapsToNull(t *testing.T) {
-	t.Parallel()
-	w := &serverv1.BackgroundPersistenceWriterSpecs{
-		Name:              "go-metrics-bus-writer",
-		BusSubscriberType: "GO_METRICS_BUS_WRITER",
-		Limit:             &serverv1.KubeResourceConfig{},
-		Request:           &serverv1.KubeResourceConfig{},
-	}
-	m := decodeSingleWriter(t, w)
-
-	assert.Nil(t, m.Limit, "an all-empty server limit must decode to nil (null), not {}")
-	assert.Nil(t, m.Request, "an all-empty server request must decode to nil (null), not {}")
-}
-
-// TestBgpWritersProtoToTF_PartialLimitPreserved ensures a partially-populated
-// limit/request keeps its set fields and nulls only the empty ones — the guard
-// must not swallow a genuinely-configured object.
-func TestBgpWritersProtoToTF_PartialLimitPreserved(t *testing.T) {
-	t.Parallel()
-	w := &serverv1.BackgroundPersistenceWriterSpecs{
-		Name:              "offline-writer",
-		BusSubscriberType: "OFFLINE_WRITER",
-		Limit:             &serverv1.KubeResourceConfig{Cpu: "1000m"},
-	}
-	m := decodeSingleWriter(t, w)
-
-	require.NotNil(t, m.Limit)
-	assert.Equal(t, types.StringValue("1000m"), m.Limit.CPU)
-	assert.Equal(t, types.StringNull(), m.Limit.Memory)
-	assert.Equal(t, types.StringNull(), m.Limit.EphemeralStorage)
-	assert.Equal(t, types.StringNull(), m.Limit.Storage)
-	assert.Nil(t, m.Request, "request the server didn't send stays nil")
-}
-
 // TestBgpWritersProtoToTF_ProtoRoundTrip converts proto -> TF -> proto and asserts
 // semantic equality for a fully-populated writer. Guards the decoder from drifting
 // away from the encoder.


### PR DESCRIPTION
This reverts commit fabdd9844da6cd6591b9213fb158fa43c3c85cf7. Based on discussion the observed drift was caused due to manual edits; we should normalize in the server to handle this case.