### PR TITLE
Cluster-level config on cluster resources

### DIFF
--- a/docs/resources/kubernetes_cluster.md
+++ b/docs/resources/kubernetes_cluster.md
@@ -27,7 +27,7 @@ Chalk Kubernetes cluster resource (unmanaged)
 
 - `cloud_credential_id` (String) ID of the cloud credential to use for the cluster
 - `data_plane_controller` (Attributes) Dataplane controller configuration, required to use Chalk Compute. (see [below for nested schema](#nestedatt--data_plane_controller))
-- `data_plane_redis` (Attributes) Optional Redis instance for cluster operators to use as a shared cache. Specify exactly one of `managed` or `self_hosted`. (see [below for nested schema](#nestedatt--data_plane_redis))
+- `data_plane_redis` (Attributes) Optional Redis instance for cluster. Specify exactly one of `managed` or `self_hosted`. (see [below for nested schema](#nestedatt--data_plane_redis))
 - `dns_zone` (String) DNS zone for the cluster
 - `maintenance_window` (Attributes) Controls when disruptive maintenance operations may run on this cluster. (see [below for nested schema](#nestedatt--maintenance_window))
 
@@ -41,24 +41,24 @@ Chalk Kubernetes cluster resource (unmanaged)
 
 Optional:
 
-- `host_pools` (Attributes List) Host pools to deploy for this cluster. Each entry provisions a ChalkHostPool. (see [below for nested schema](#nestedatt--data_plane_controller--host_pools))
-- `node_pool` (String) Node pool to pin non-gVisor (open) container/scaling-group workloads to.
-- `restricted_node_pool` (String) Node pool to pin gVisor (restricted) container/scaling-group workloads to.
-- `tier` (String) Resource tier for the dataplane controller. One of `DISABLED`, `SMALL`, `MEDIUM`, `LARGE`. Unset resolves to `SMALL` server-side.
+- `host_pools` (Attributes List) Host pools to deploy for this cluster. (see [below for nested schema](#nestedatt--data_plane_controller--host_pools))
+- `node_pool` (String) Node pool to pin non-restricted (open) container/scaling-group workloads to.
+- `restricted_node_pool` (String) Node pool to pin restricted container/scaling-group workloads to.
+- `tier` (String) Resource tier for the dataplane controller. One of `DISABLED`, `SMALL`, `MEDIUM`, `LARGE`.
 
 <a id="nestedatt--data_plane_controller--host_pools"></a>
 ### Nested Schema for `data_plane_controller.host_pools`
 
 Required:
 
-- `count` (Number) Number of hypervisor pods in the pool.
-- `name` (String) Name of the pool. Must be a valid DNS label.
+- `count` (Number) Number of hosts in the pool.
+- `name` (String) Name of the pool.
 
 Optional:
 
-- `cpu` (String) CPU resources for each hypervisor pod, e.g. `4`.
-- `machine_family` (String) Machine family for this pool's hosts to run on. Unset lets the server pick a default.
-- `memory` (String) Memory resources for each hypervisor pod, e.g. `8Gi`.
+- `cpu` (String) CPU resources for each host, e.g. `4`.
+- `machine_family` (String) Machine family for this pool's hosts to run on.
+- `memory` (String) Memory resources for each host, e.g. `8Gi`.
 
 
 
@@ -68,7 +68,7 @@ Optional:
 Optional:
 
 - `managed` (Attributes) Provision a Chalk-managed Redis instance. (see [below for nested schema](#nestedatt--data_plane_redis--managed))
-- `self_hosted` (Attributes) Use a self-hosted Redis instance. Defined for forward compatibility but not yet supported server-side. (see [below for nested schema](#nestedatt--data_plane_redis--self_hosted))
+- `self_hosted` (Attributes) Use a self-hosted Redis instance. (see [below for nested schema](#nestedatt--data_plane_redis--self_hosted))
 
 <a id="nestedatt--data_plane_redis--managed"></a>
 ### Nested Schema for `data_plane_redis.managed`

--- a/docs/resources/kubernetes_cluster.md
+++ b/docs/resources/kubernetes_cluster.md
@@ -27,7 +27,7 @@ Chalk Kubernetes cluster resource (unmanaged)
 
 - `cloud_credential_id` (String) ID of the cloud credential to use for the cluster
 - `data_plane_controller` (Attributes) Dataplane controller configuration, required to use Chalk Compute. (see [below for nested schema](#nestedatt--data_plane_controller))
-- `data_plane_redis` (Attributes) Optional Redis instance for cluster operators to use as a shared cache. (see [below for nested schema](#nestedatt--data_plane_redis))
+- `data_plane_redis` (Attributes) Optional Redis instance for cluster operators to use as a shared cache. Specify exactly one of `managed` or `self_hosted`. (see [below for nested schema](#nestedatt--data_plane_redis))
 - `dns_zone` (String) DNS zone for the cluster
 - `maintenance_window` (Attributes) Controls when disruptive maintenance operations may run on this cluster. (see [below for nested schema](#nestedatt--maintenance_window))
 
@@ -66,10 +66,25 @@ Optional:
 
 Optional:
 
-- `cloud_secret_name` (String) Name of the cloud secret holding credentials for a self-hosted Redis instance (only used when `kind = SELF_HOSTED`).
+- `managed` (Attributes) Provision a Chalk-managed Redis instance. (see [below for nested schema](#nestedatt--data_plane_redis--managed))
+- `self_hosted` (Attributes) Use a self-hosted Redis instance. Defined for forward compatibility but not yet supported server-side. (see [below for nested schema](#nestedatt--data_plane_redis--self_hosted))
+
+<a id="nestedatt--data_plane_redis--managed"></a>
+### Nested Schema for `data_plane_redis.managed`
+
+Optional:
+
 - `cpu` (String) CPU size of the Redis instance, e.g. `500m`, `1`.
-- `kind` (String) Redis provisioning kind. `MANAGED` provisions a Chalk-managed instance. `SELF_HOSTED` is defined but not yet supported server-side.
 - `memory` (String) Memory size of the Redis instance, e.g. `1Gi`, `2Gi`.
+
+
+<a id="nestedatt--data_plane_redis--self_hosted"></a>
+### Nested Schema for `data_plane_redis.self_hosted`
+
+Required:
+
+- `cloud_secret_name` (String) Name of the cloud secret holding credentials for the self-hosted Redis instance.
+
 
 
 <a id="nestedatt--maintenance_window"></a>

--- a/docs/resources/kubernetes_cluster.md
+++ b/docs/resources/kubernetes_cluster.md
@@ -26,9 +26,60 @@ Chalk Kubernetes cluster resource (unmanaged)
 ### Optional
 
 - `cloud_credential_id` (String) ID of the cloud credential to use for the cluster
+- `data_plane_controller` (Attributes) Dataplane controller configuration, required to use Chalk Compute. (see [below for nested schema](#nestedatt--data_plane_controller))
+- `data_plane_redis` (Attributes) Optional Redis instance for cluster operators to use as a shared cache. (see [below for nested schema](#nestedatt--data_plane_redis))
 - `dns_zone` (String) DNS zone for the cluster
+- `maintenance_window` (Attributes) Controls when disruptive maintenance operations may run on this cluster. (see [below for nested schema](#nestedatt--maintenance_window))
 
 ### Read-Only
 
 - `id` (String) Cluster identifier
 - `team_id` (String) Team ID
+
+<a id="nestedatt--data_plane_controller"></a>
+### Nested Schema for `data_plane_controller`
+
+Optional:
+
+- `host_pools` (Attributes List) Host pools to deploy for this cluster. Each entry provisions a ChalkHostPool. (see [below for nested schema](#nestedatt--data_plane_controller--host_pools))
+- `node_pool` (String) Node pool to pin non-gVisor (open) container/scaling-group workloads to.
+- `restricted_node_pool` (String) Node pool to pin gVisor (restricted) container/scaling-group workloads to.
+- `tier` (String) Resource tier for the dataplane controller. One of `DISABLED`, `SMALL`, `MEDIUM`, `LARGE`. Unset resolves to `SMALL` server-side.
+
+<a id="nestedatt--data_plane_controller--host_pools"></a>
+### Nested Schema for `data_plane_controller.host_pools`
+
+Required:
+
+- `count` (Number) Number of hypervisor pods in the pool.
+- `name` (String) Name of the pool. Must be a valid DNS label.
+
+Optional:
+
+- `cpu` (String) CPU resources for each hypervisor pod, e.g. `4`.
+- `memory` (String) Memory resources for each hypervisor pod, e.g. `8Gi`.
+
+
+
+<a id="nestedatt--data_plane_redis"></a>
+### Nested Schema for `data_plane_redis`
+
+Optional:
+
+- `cloud_secret_name` (String) Name of the cloud secret holding credentials for a self-hosted Redis instance (only used when `kind = SELF_HOSTED`).
+- `cpu` (String) CPU size of the Redis instance, e.g. `500m`, `1`.
+- `kind` (String) Redis provisioning kind. `MANAGED` provisions a Chalk-managed instance. `SELF_HOSTED` is defined but not yet supported server-side.
+- `memory` (String) Memory size of the Redis instance, e.g. `1Gi`, `2Gi`.
+
+
+<a id="nestedatt--maintenance_window"></a>
+### Nested Schema for `maintenance_window`
+
+Required:
+
+- `mode` (String) Maintenance scheduling mode. `UNSPECIFIED` uses the system default window, `UNRESTRICTED` allows operations at any time, and `CUSTOM` uses `schedule`/`duration`.
+
+Optional:
+
+- `duration` (String) How long the window stays open, e.g. `30m` or `1h`. Required when `mode = CUSTOM`.
+- `schedule` (String) 5-field UTC cron expression defining when the window opens, e.g. `0 2 * * *`. Required when `mode = CUSTOM`.

--- a/docs/resources/kubernetes_cluster.md
+++ b/docs/resources/kubernetes_cluster.md
@@ -57,6 +57,7 @@ Required:
 Optional:
 
 - `cpu` (String) CPU resources for each hypervisor pod, e.g. `4`.
+- `machine_family` (String) Machine family for this pool's hosts to run on. Unset lets the server pick a default.
 - `memory` (String) Memory resources for each hypervisor pod, e.g. `8Gi`.
 
 

--- a/docs/resources/managed_cluster.md
+++ b/docs/resources/managed_cluster.md
@@ -23,9 +23,63 @@ Chalk managed Kubernetes cluster resource. Creates a fully managed cluster using
 - `cloud_credential_id` (String) ID of the cloud credential to use for the managed cluster
 - `vpc_id` (String) ID of the VPC to use for the cluster
 
+### Optional
+
+- `data_plane_controller` (Attributes) Dataplane controller configuration, required to use Chalk Compute. (see [below for nested schema](#nestedatt--data_plane_controller))
+- `data_plane_redis` (Attributes) Optional Redis instance for cluster operators to use as a shared cache. (see [below for nested schema](#nestedatt--data_plane_redis))
+- `maintenance_window` (Attributes) Controls when disruptive maintenance operations may run on this cluster. (see [below for nested schema](#nestedatt--maintenance_window))
+
 ### Read-Only
 
 - `designator` (String) Cluster designator
 - `id` (String) Cluster identifier
 - `kind` (String) Cloud provider kind (e.g., 'EKS_STANDARD', 'EKS_AUTOPILOT', 'GKE_STANDARD', 'GKE_AUTOPILOT')
 - `name` (String) Cluster name
+
+<a id="nestedatt--data_plane_controller"></a>
+### Nested Schema for `data_plane_controller`
+
+Optional:
+
+- `host_pools` (Attributes List) Host pools to deploy for this cluster. Each entry provisions a ChalkHostPool. (see [below for nested schema](#nestedatt--data_plane_controller--host_pools))
+- `node_pool` (String) Node pool to pin non-gVisor (open) container/scaling-group workloads to.
+- `restricted_node_pool` (String) Node pool to pin gVisor (restricted) container/scaling-group workloads to.
+- `tier` (String) Resource tier for the dataplane controller. One of `DISABLED`, `SMALL`, `MEDIUM`, `LARGE`. Unset resolves to `SMALL` server-side.
+
+<a id="nestedatt--data_plane_controller--host_pools"></a>
+### Nested Schema for `data_plane_controller.host_pools`
+
+Required:
+
+- `count` (Number) Number of hypervisor pods in the pool.
+- `name` (String) Name of the pool. Must be a valid DNS label.
+
+Optional:
+
+- `cpu` (String) CPU resources for each hypervisor pod, e.g. `4`.
+- `memory` (String) Memory resources for each hypervisor pod, e.g. `8Gi`.
+
+
+
+<a id="nestedatt--data_plane_redis"></a>
+### Nested Schema for `data_plane_redis`
+
+Optional:
+
+- `cloud_secret_name` (String) Name of the cloud secret holding credentials for a self-hosted Redis instance (only used when `kind = SELF_HOSTED`).
+- `cpu` (String) CPU size of the Redis instance, e.g. `500m`, `1`.
+- `kind` (String) Redis provisioning kind. `MANAGED` provisions a Chalk-managed instance. `SELF_HOSTED` is defined but not yet supported server-side.
+- `memory` (String) Memory size of the Redis instance, e.g. `1Gi`, `2Gi`.
+
+
+<a id="nestedatt--maintenance_window"></a>
+### Nested Schema for `maintenance_window`
+
+Required:
+
+- `mode` (String) Maintenance scheduling mode. `UNSPECIFIED` uses the system default window, `UNRESTRICTED` allows operations at any time, and `CUSTOM` uses `schedule`/`duration`.
+
+Optional:
+
+- `duration` (String) How long the window stays open, e.g. `30m` or `1h`. Required when `mode = CUSTOM`.
+- `schedule` (String) 5-field UTC cron expression defining when the window opens, e.g. `0 2 * * *`. Required when `mode = CUSTOM`.

--- a/docs/resources/managed_cluster.md
+++ b/docs/resources/managed_cluster.md
@@ -26,7 +26,7 @@ Chalk managed Kubernetes cluster resource. Creates a fully managed cluster using
 ### Optional
 
 - `data_plane_controller` (Attributes) Dataplane controller configuration, required to use Chalk Compute. (see [below for nested schema](#nestedatt--data_plane_controller))
-- `data_plane_redis` (Attributes) Optional Redis instance for cluster operators to use as a shared cache. (see [below for nested schema](#nestedatt--data_plane_redis))
+- `data_plane_redis` (Attributes) Optional Redis instance for cluster operators to use as a shared cache. Specify exactly one of `managed` or `self_hosted`. (see [below for nested schema](#nestedatt--data_plane_redis))
 - `maintenance_window` (Attributes) Controls when disruptive maintenance operations may run on this cluster. (see [below for nested schema](#nestedatt--maintenance_window))
 
 ### Read-Only
@@ -66,10 +66,25 @@ Optional:
 
 Optional:
 
-- `cloud_secret_name` (String) Name of the cloud secret holding credentials for a self-hosted Redis instance (only used when `kind = SELF_HOSTED`).
+- `managed` (Attributes) Provision a Chalk-managed Redis instance. (see [below for nested schema](#nestedatt--data_plane_redis--managed))
+- `self_hosted` (Attributes) Use a self-hosted Redis instance. Defined for forward compatibility but not yet supported server-side. (see [below for nested schema](#nestedatt--data_plane_redis--self_hosted))
+
+<a id="nestedatt--data_plane_redis--managed"></a>
+### Nested Schema for `data_plane_redis.managed`
+
+Optional:
+
 - `cpu` (String) CPU size of the Redis instance, e.g. `500m`, `1`.
-- `kind` (String) Redis provisioning kind. `MANAGED` provisions a Chalk-managed instance. `SELF_HOSTED` is defined but not yet supported server-side.
 - `memory` (String) Memory size of the Redis instance, e.g. `1Gi`, `2Gi`.
+
+
+<a id="nestedatt--data_plane_redis--self_hosted"></a>
+### Nested Schema for `data_plane_redis.self_hosted`
+
+Required:
+
+- `cloud_secret_name` (String) Name of the cloud secret holding credentials for the self-hosted Redis instance.
+
 
 
 <a id="nestedatt--maintenance_window"></a>

--- a/docs/resources/managed_cluster.md
+++ b/docs/resources/managed_cluster.md
@@ -26,7 +26,7 @@ Chalk managed Kubernetes cluster resource. Creates a fully managed cluster using
 ### Optional
 
 - `data_plane_controller` (Attributes) Dataplane controller configuration, required to use Chalk Compute. (see [below for nested schema](#nestedatt--data_plane_controller))
-- `data_plane_redis` (Attributes) Optional Redis instance for cluster operators to use as a shared cache. Specify exactly one of `managed` or `self_hosted`. (see [below for nested schema](#nestedatt--data_plane_redis))
+- `data_plane_redis` (Attributes) Optional Redis instance for cluster. Specify exactly one of `managed` or `self_hosted`. (see [below for nested schema](#nestedatt--data_plane_redis))
 - `maintenance_window` (Attributes) Controls when disruptive maintenance operations may run on this cluster. (see [below for nested schema](#nestedatt--maintenance_window))
 
 ### Read-Only
@@ -41,24 +41,24 @@ Chalk managed Kubernetes cluster resource. Creates a fully managed cluster using
 
 Optional:
 
-- `host_pools` (Attributes List) Host pools to deploy for this cluster. Each entry provisions a ChalkHostPool. (see [below for nested schema](#nestedatt--data_plane_controller--host_pools))
-- `node_pool` (String) Node pool to pin non-gVisor (open) container/scaling-group workloads to.
-- `restricted_node_pool` (String) Node pool to pin gVisor (restricted) container/scaling-group workloads to.
-- `tier` (String) Resource tier for the dataplane controller. One of `DISABLED`, `SMALL`, `MEDIUM`, `LARGE`. Unset resolves to `SMALL` server-side.
+- `host_pools` (Attributes List) Host pools to deploy for this cluster. (see [below for nested schema](#nestedatt--data_plane_controller--host_pools))
+- `node_pool` (String) Node pool to pin non-restricted (open) container/scaling-group workloads to.
+- `restricted_node_pool` (String) Node pool to pin restricted container/scaling-group workloads to.
+- `tier` (String) Resource tier for the dataplane controller. One of `DISABLED`, `SMALL`, `MEDIUM`, `LARGE`.
 
 <a id="nestedatt--data_plane_controller--host_pools"></a>
 ### Nested Schema for `data_plane_controller.host_pools`
 
 Required:
 
-- `count` (Number) Number of hypervisor pods in the pool.
-- `name` (String) Name of the pool. Must be a valid DNS label.
+- `count` (Number) Number of hosts in the pool.
+- `name` (String) Name of the pool.
 
 Optional:
 
-- `cpu` (String) CPU resources for each hypervisor pod, e.g. `4`.
-- `machine_family` (String) Machine family for this pool's hosts to run on. Unset lets the server pick a default.
-- `memory` (String) Memory resources for each hypervisor pod, e.g. `8Gi`.
+- `cpu` (String) CPU resources for each host, e.g. `4`.
+- `machine_family` (String) Machine family for this pool's hosts to run on.
+- `memory` (String) Memory resources for each host, e.g. `8Gi`.
 
 
 
@@ -68,7 +68,7 @@ Optional:
 Optional:
 
 - `managed` (Attributes) Provision a Chalk-managed Redis instance. (see [below for nested schema](#nestedatt--data_plane_redis--managed))
-- `self_hosted` (Attributes) Use a self-hosted Redis instance. Defined for forward compatibility but not yet supported server-side. (see [below for nested schema](#nestedatt--data_plane_redis--self_hosted))
+- `self_hosted` (Attributes) Use a self-hosted Redis instance. (see [below for nested schema](#nestedatt--data_plane_redis--self_hosted))
 
 <a id="nestedatt--data_plane_redis--managed"></a>
 ### Nested Schema for `data_plane_redis.managed`

--- a/docs/resources/managed_cluster.md
+++ b/docs/resources/managed_cluster.md
@@ -57,6 +57,7 @@ Required:
 Optional:
 
 - `cpu` (String) CPU resources for each hypervisor pod, e.g. `4`.
+- `machine_family` (String) Machine family for this pool's hosts to run on. Unset lets the server pick a default.
 - `memory` (String) Memory resources for each hypervisor pod, e.g. `8Gi`.
 
 

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.26.1
 
 require (
 	connectrpc.com/connect v1.19.1
-	github.com/chalk-ai/chalk-go v1.2.276
-	github.com/chalk-ai/chalk-go/gen v1.2.276
+	github.com/chalk-ai/chalk-go v1.2.278
+	github.com/chalk-ai/chalk-go/gen v1.2.278
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/terraform-plugin-docs v0.24.0
 	github.com/hashicorp/terraform-plugin-framework v1.14.1

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.26.1
 
 require (
 	connectrpc.com/connect v1.19.1
-	github.com/chalk-ai/chalk-go v1.2.274
-	github.com/chalk-ai/chalk-go/gen v1.2.274
+	github.com/chalk-ai/chalk-go v1.2.276
+	github.com/chalk-ai/chalk-go/gen v1.2.276
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/terraform-plugin-docs v0.24.0
 	github.com/hashicorp/terraform-plugin-framework v1.14.1

--- a/go.sum
+++ b/go.sum
@@ -35,10 +35,10 @@ github.com/bufbuild/protocompile v0.14.1 h1:iA73zAf/fyljNjQKwYzUHD6AD4R8KMasmwa/
 github.com/bufbuild/protocompile v0.14.1/go.mod h1:ppVdAIhbr2H8asPk6k4pY7t9zB1OU5DoEw9xY/FUi1c=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/chalk-ai/chalk-go v1.2.274 h1:N7hSt6i42cYkMWNqey+JfrKjEaTtpJjwJBTqaiQ/Nzs=
-github.com/chalk-ai/chalk-go v1.2.274/go.mod h1:Nw+JJY46b5cs7kYwUPHd0+8tehurvFddyE+1BO/DKhI=
-github.com/chalk-ai/chalk-go/gen v1.2.274 h1:2lte/AinrNX7xt0P8lrVLNp/uNgZj+Ada1fMfg/t2lQ=
-github.com/chalk-ai/chalk-go/gen v1.2.274/go.mod h1:Cd47/VOgt1NJD9LOeSGxiypc8hLOGZ4y8NTO13uVnzc=
+github.com/chalk-ai/chalk-go v1.2.276 h1:PvpHtep0kXTiUcM8hHju4ikhzLGasFwjD5+b4W2R4mg=
+github.com/chalk-ai/chalk-go v1.2.276/go.mod h1:Nw+JJY46b5cs7kYwUPHd0+8tehurvFddyE+1BO/DKhI=
+github.com/chalk-ai/chalk-go/gen v1.2.276 h1:ljgQC3PtgCWIZkDUynw7Uaw5ACqIm+aLfbAOdrZYj1U=
+github.com/chalk-ai/chalk-go/gen v1.2.276/go.mod h1:Cd47/VOgt1NJD9LOeSGxiypc8hLOGZ4y8NTO13uVnzc=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
 github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=

--- a/go.sum
+++ b/go.sum
@@ -35,10 +35,10 @@ github.com/bufbuild/protocompile v0.14.1 h1:iA73zAf/fyljNjQKwYzUHD6AD4R8KMasmwa/
 github.com/bufbuild/protocompile v0.14.1/go.mod h1:ppVdAIhbr2H8asPk6k4pY7t9zB1OU5DoEw9xY/FUi1c=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/chalk-ai/chalk-go v1.2.276 h1:PvpHtep0kXTiUcM8hHju4ikhzLGasFwjD5+b4W2R4mg=
-github.com/chalk-ai/chalk-go v1.2.276/go.mod h1:Nw+JJY46b5cs7kYwUPHd0+8tehurvFddyE+1BO/DKhI=
-github.com/chalk-ai/chalk-go/gen v1.2.276 h1:ljgQC3PtgCWIZkDUynw7Uaw5ACqIm+aLfbAOdrZYj1U=
-github.com/chalk-ai/chalk-go/gen v1.2.276/go.mod h1:Cd47/VOgt1NJD9LOeSGxiypc8hLOGZ4y8NTO13uVnzc=
+github.com/chalk-ai/chalk-go v1.2.278 h1:sT06+lfus0A2MVxhqUB3eHMzIhyWD9Y6z12NRD1OOBo=
+github.com/chalk-ai/chalk-go v1.2.278/go.mod h1:Nw+JJY46b5cs7kYwUPHd0+8tehurvFddyE+1BO/DKhI=
+github.com/chalk-ai/chalk-go/gen v1.2.278 h1:Ovt1EPBRpeOuO47POnXKXqv7RMq7a6X0NtzO8qiQPlc=
+github.com/chalk-ai/chalk-go/gen v1.2.278/go.mod h1:Cd47/VOgt1NJD9LOeSGxiypc8hLOGZ4y8NTO13uVnzc=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
 github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=

--- a/internal/provider/cluster_config_common.go
+++ b/internal/provider/cluster_config_common.go
@@ -100,10 +100,11 @@ type dataPlaneControllerModel struct {
 }
 
 type hostPoolModel struct {
-	Name   types.String `tfsdk:"name"`
-	Count  types.Int64  `tfsdk:"count"`
-	Cpu    types.String `tfsdk:"cpu"`
-	Memory types.String `tfsdk:"memory"`
+	Name          types.String `tfsdk:"name"`
+	Count         types.Int64  `tfsdk:"count"`
+	Cpu           types.String `tfsdk:"cpu"`
+	Memory        types.String `tfsdk:"memory"`
+	MachineFamily types.String `tfsdk:"machine_family"`
 }
 
 // clusterConfigSchemaAttributes returns the shared cluster-level config
@@ -215,6 +216,10 @@ func clusterConfigSchemaAttributes() map[string]schema.Attribute {
 								MarkdownDescription: "Memory resources for each hypervisor pod, e.g. `8Gi`.",
 								Optional:            true,
 							},
+							"machine_family": schema.StringAttribute{
+								MarkdownDescription: "Machine family for this pool's hosts to run on. Unset lets the server pick a default.",
+								Optional:            true,
+							},
 						},
 					},
 				},
@@ -282,10 +287,11 @@ func (m *dataPlaneControllerModel) toProto() *serverv1.DataplaneController {
 	}
 	for _, pool := range m.HostPools {
 		c.HostPools = append(c.HostPools, &serverv1.ChalkHostPool{
-			Name:   pool.Name.ValueString(),
-			Count:  int32(pool.Count.ValueInt64()),
-			Cpu:    optionalStringPtr(pool.Cpu),
-			Memory: optionalStringPtr(pool.Memory),
+			Name:          pool.Name.ValueString(),
+			Count:         int32(pool.Count.ValueInt64()),
+			Cpu:           optionalStringPtr(pool.Cpu),
+			Memory:        optionalStringPtr(pool.Memory),
+			MachineFamily: optionalStringPtr(pool.MachineFamily),
 		})
 	}
 	return c
@@ -342,10 +348,11 @@ func dataPlaneControllerFromProto(p *serverv1.DataplaneController) *dataPlaneCon
 	}
 	for _, pool := range p.GetHostPools() {
 		m.HostPools = append(m.HostPools, hostPoolModel{
-			Name:   types.StringValue(pool.GetName()),
-			Count:  types.Int64Value(int64(pool.GetCount())),
-			Cpu:    optionalStringValue(pool.GetCpu()),
-			Memory: optionalStringValue(pool.GetMemory()),
+			Name:          types.StringValue(pool.GetName()),
+			Count:         types.Int64Value(int64(pool.GetCount())),
+			Cpu:           optionalStringValue(pool.GetCpu()),
+			Memory:        optionalStringValue(pool.GetMemory()),
+			MachineFamily: optionalStringValue(pool.GetMachineFamily()),
 		})
 	}
 	return m

--- a/internal/provider/cluster_config_common.go
+++ b/internal/provider/cluster_config_common.go
@@ -265,7 +265,7 @@ func (m *dataPlaneRedisModel) toProto() *serverv1.DataPlaneRedis {
 		kind := dataPlaneRedisKindSelfHosted
 		return &serverv1.DataPlaneRedis{
 			Kind:            &kind,
-			CloudSecretName: optionalStringPtr(m.SelfHosted.CloudSecretName),
+			CloudSecretName: m.SelfHosted.CloudSecretName.ValueStringPointer(),
 		}
 	}
 	// Exactly one of managed/self_hosted is set (enforced by schema validators),
@@ -273,8 +273,8 @@ func (m *dataPlaneRedisModel) toProto() *serverv1.DataPlaneRedis {
 	kind := dataPlaneRedisKindManaged
 	return &serverv1.DataPlaneRedis{
 		Kind:   &kind,
-		Memory: optionalStringPtr(m.Managed.Memory),
-		Cpu:    optionalStringPtr(m.Managed.Cpu),
+		Memory: m.Managed.Memory.ValueStringPointer(),
+		Cpu:    m.Managed.Cpu.ValueStringPointer(),
 	}
 }
 
@@ -284,16 +284,16 @@ func (m *dataPlaneControllerModel) toProto() *serverv1.DataplaneController {
 	}
 	c := &serverv1.DataplaneController{
 		Tier:               dataPlaneControllerTierToProto[m.Tier.ValueString()],
-		NodePool:           optionalStringPtr(m.NodePool),
-		RestrictedNodePool: optionalStringPtr(m.RestrictedNodePool),
+		NodePool:           m.NodePool.ValueStringPointer(),
+		RestrictedNodePool: m.RestrictedNodePool.ValueStringPointer(),
 	}
 	for _, pool := range m.HostPools {
 		c.HostPools = append(c.HostPools, &serverv1.ChalkHostPool{
 			Name:          pool.Name.ValueString(),
 			Count:         int32(pool.Count.ValueInt64()),
-			Cpu:           optionalStringPtr(pool.Cpu),
-			Memory:        optionalStringPtr(pool.Memory),
-			MachineFamily: optionalStringPtr(pool.MachineFamily),
+			Cpu:           pool.Cpu.ValueStringPointer(),
+			Memory:        pool.Memory.ValueStringPointer(),
+			MachineFamily: pool.MachineFamily.ValueStringPointer(),
 		})
 	}
 	return c
@@ -321,15 +321,15 @@ func dataPlaneRedisFromProto(p *serverv1.DataPlaneRedis) *dataPlaneRedisModel {
 	if p.GetKind() == dataPlaneRedisKindSelfHosted {
 		return &dataPlaneRedisModel{
 			SelfHosted: &dataPlaneRedisSelfHostedModel{
-				CloudSecretName: optionalStringValue(p.GetCloudSecretName()),
+				CloudSecretName: stringPointerValue(p.CloudSecretName),
 			},
 		}
 	}
 	// The server treats an empty kind the same as MANAGED.
 	return &dataPlaneRedisModel{
 		Managed: &dataPlaneRedisManagedModel{
-			Memory: optionalStringValue(p.GetMemory()),
-			Cpu:    optionalStringValue(p.GetCpu()),
+			Memory: stringPointerValue(p.Memory),
+			Cpu:    stringPointerValue(p.Cpu),
 		},
 	}
 }
@@ -345,28 +345,17 @@ func dataPlaneControllerFromProto(p *serverv1.DataplaneController) *dataPlaneCon
 	}
 	m := &dataPlaneControllerModel{
 		Tier:               optionalStringValue(dataPlaneControllerTierFromProto[p.GetTier()]),
-		NodePool:           optionalStringValue(p.GetNodePool()),
-		RestrictedNodePool: optionalStringValue(p.GetRestrictedNodePool()),
+		NodePool:           stringPointerValue(p.NodePool),
+		RestrictedNodePool: stringPointerValue(p.RestrictedNodePool),
 	}
 	for _, pool := range p.GetHostPools() {
 		m.HostPools = append(m.HostPools, hostPoolModel{
 			Name:          types.StringValue(pool.GetName()),
 			Count:         types.Int64Value(int64(pool.GetCount())),
-			Cpu:           optionalStringValue(pool.GetCpu()),
-			Memory:        optionalStringValue(pool.GetMemory()),
-			MachineFamily: optionalStringValue(pool.GetMachineFamily()),
+			Cpu:           stringPointerValue(pool.Cpu),
+			Memory:        stringPointerValue(pool.Memory),
+			MachineFamily: stringPointerValue(pool.MachineFamily),
 		})
 	}
 	return m
-}
-
-// optionalStringPtr converts a types.String to a *string, returning nil for
-// null, unknown, or empty values so unset optional fields are omitted from the
-// proto rather than sent as empty strings.
-func optionalStringPtr(s types.String) *string {
-	if s.IsNull() || s.IsUnknown() || s.ValueString() == "" {
-		return nil
-	}
-	v := s.ValueString()
-	return &v
 }

--- a/internal/provider/cluster_config_common.go
+++ b/internal/provider/cluster_config_common.go
@@ -3,6 +3,7 @@ package provider
 import (
 	serverv1 "github.com/chalk-ai/chalk-go/gen/chalk/server/v1"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/objectvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -12,16 +13,9 @@ import (
 )
 
 // This file holds the cluster-level configuration that both chalk_managed_cluster
-// and chalk_kubernetes_cluster expose on the CloudComponentCluster spec:
-// maintenance_window, data_plane_redis, and data_plane_controller. Both resources
-// share the schema, expand (model -> proto) and flatten (proto -> model) logic so
-// the two stay in lockstep.
-//
-// The server (go-api-server/cloudcomponents) treats all three blocks as the only
-// mutable spec fields, applying them identically for managed and unmanaged
-// clusters, which is why the config is common.
+// and chalk_kubernetes_cluster expose on the CloudComponentCluster spec.
 
-// Maintenance window modes, exposed as short (prefix-stripped) tokens.
+// Maintenance window modes, exposed as short (prefix-stripped) strings.
 const (
 	maintenanceModeUnspecified  = "UNSPECIFIED"
 	maintenanceModeUnrestricted = "UNRESTRICTED"
@@ -29,14 +23,13 @@ const (
 )
 
 // Data plane redis kinds. These are free-form strings the server matches
-// case-sensitively, so the tokens must match exactly (see
-// go-api-server/cloudcomponents/utils.go validateDataPlaneRedisSpec).
+// case-sensitively, so they must match exactly.
 const (
 	dataPlaneRedisKindManaged    = "MANAGED"
 	dataPlaneRedisKindSelfHosted = "SELF_HOSTED"
 )
 
-// Dataplane controller tiers, exposed as short (prefix-stripped) tokens.
+// Dataplane controller tiers, exposed as short (prefix-stripped) strings.
 const (
 	dataPlaneControllerTierDisabled = "DISABLED"
 	dataPlaneControllerTierSmall    = "SMALL"
@@ -76,8 +69,6 @@ type maintenanceWindowModel struct {
 	Duration types.String `tfsdk:"duration"`
 }
 
-// dataPlaneRedisModel splits config by provisioning kind: exactly one of managed
-// or self_hosted is set, and the kind is derived from which one is present.
 type dataPlaneRedisModel struct {
 	Managed    *dataPlaneRedisManagedModel    `tfsdk:"managed"`
 	SelfHosted *dataPlaneRedisSelfHostedModel `tfsdk:"self_hosted"`
@@ -109,7 +100,7 @@ type hostPoolModel struct {
 
 // clusterConfigSchemaAttributes returns the shared cluster-level config
 // attributes to merge into a cluster resource's schema. All three blocks are
-// optional; omitting one leaves the corresponding spec field unset.
+// optional.
 func clusterConfigSchemaAttributes() map[string]schema.Attribute {
 	return map[string]schema.Attribute{
 		"maintenance_window": schema.SingleNestedAttribute{
@@ -134,7 +125,7 @@ func clusterConfigSchemaAttributes() map[string]schema.Attribute {
 			},
 		},
 		"data_plane_redis": schema.SingleNestedAttribute{
-			MarkdownDescription: "Optional Redis instance for cluster operators to use as a shared cache. Specify exactly one of `managed` or `self_hosted`.",
+			MarkdownDescription: "Optional Redis instance for cluster. Specify exactly one of `managed` or `self_hosted`.",
 			Optional:            true,
 			Attributes: map[string]schema.Attribute{
 				"managed": schema.SingleNestedAttribute{
@@ -157,7 +148,7 @@ func clusterConfigSchemaAttributes() map[string]schema.Attribute {
 					},
 				},
 				"self_hosted": schema.SingleNestedAttribute{
-					MarkdownDescription: "Use a self-hosted Redis instance. Defined for forward compatibility but not yet supported server-side.",
+					MarkdownDescription: "Use a self-hosted Redis instance.",
 					Optional:            true,
 					Validators: []validator.Object{
 						objectvalidator.ExactlyOneOf(
@@ -178,46 +169,59 @@ func clusterConfigSchemaAttributes() map[string]schema.Attribute {
 			Optional:            true,
 			Attributes: map[string]schema.Attribute{
 				"tier": schema.StringAttribute{
-					MarkdownDescription: "Resource tier for the dataplane controller. One of `DISABLED`, `SMALL`, `MEDIUM`, `LARGE`. Unset resolves to `SMALL` server-side.",
+					MarkdownDescription: "Resource tier for the dataplane controller. One of `DISABLED`, `SMALL`, `MEDIUM`, `LARGE`.",
 					Optional:            true,
 					Validators: []validator.String{
 						stringvalidator.OneOf(dataPlaneControllerTierDisabled, dataPlaneControllerTierSmall, dataPlaneControllerTierMedium, dataPlaneControllerTierLarge),
+						// Reject an empty data_plane_controller block: at least one field
+						// must be set. An empty block is indistinguishable from omitting
+						// it and would otherwise drift to null after apply.
+						stringvalidator.AtLeastOneOf(
+							path.MatchRelative().AtParent().AtName("node_pool"),
+							path.MatchRelative().AtParent().AtName("restricted_node_pool"),
+							path.MatchRelative().AtParent().AtName("host_pools"),
+						),
 					},
 				},
 				"node_pool": schema.StringAttribute{
-					MarkdownDescription: "Node pool to pin non-gVisor (open) container/scaling-group workloads to.",
+					MarkdownDescription: "Node pool to pin non-restricted (open) container/scaling-group workloads to.",
 					Optional:            true,
 				},
 				"restricted_node_pool": schema.StringAttribute{
-					MarkdownDescription: "Node pool to pin gVisor (restricted) container/scaling-group workloads to.",
+					MarkdownDescription: "Node pool to pin restricted container/scaling-group workloads to.",
 					Optional:            true,
 				},
 				"host_pools": schema.ListNestedAttribute{
-					MarkdownDescription: "Host pools to deploy for this cluster. Each entry provisions a ChalkHostPool.",
+					MarkdownDescription: "Host pools to deploy for this cluster.",
 					Optional:            true,
+					Validators: []validator.List{
+						// An empty list means the same as omitting the attribute and would
+						// drift to null after apply, so require at least one entry.
+						listvalidator.SizeAtLeast(1),
+					},
 					NestedObject: schema.NestedAttributeObject{
 						Attributes: map[string]schema.Attribute{
 							"name": schema.StringAttribute{
-								MarkdownDescription: "Name of the pool. Must be a valid DNS label.",
+								MarkdownDescription: "Name of the pool.",
 								Required:            true,
 							},
 							"count": schema.Int64Attribute{
-								MarkdownDescription: "Number of hypervisor pods in the pool.",
+								MarkdownDescription: "Number of hosts in the pool.",
 								Required:            true,
 								Validators: []validator.Int64{
 									int64validator.AtLeast(1),
 								},
 							},
 							"cpu": schema.StringAttribute{
-								MarkdownDescription: "CPU resources for each hypervisor pod, e.g. `4`.",
+								MarkdownDescription: "CPU resources for each host, e.g. `4`.",
 								Optional:            true,
 							},
 							"memory": schema.StringAttribute{
-								MarkdownDescription: "Memory resources for each hypervisor pod, e.g. `8Gi`.",
+								MarkdownDescription: "Memory resources for each host, e.g. `8Gi`.",
 								Optional:            true,
 							},
 							"machine_family": schema.StringAttribute{
-								MarkdownDescription: "Machine family for this pool's hosts to run on. Unset lets the server pick a default.",
+								MarkdownDescription: "Machine family for this pool's hosts to run on.",
 								Optional:            true,
 							},
 						},
@@ -278,8 +282,6 @@ func (m *dataPlaneControllerModel) toProto() *serverv1.DataplaneController {
 	if m == nil {
 		return nil
 	}
-	// available_tiers is output-only and is cleared server-side before persist,
-	// so it is intentionally never sent.
 	c := &serverv1.DataplaneController{
 		Tier:               dataPlaneControllerTierToProto[m.Tier.ValueString()],
 		NodePool:           optionalStringPtr(m.NodePool),

--- a/internal/provider/cluster_config_common.go
+++ b/internal/provider/cluster_config_common.go
@@ -117,10 +117,16 @@ func clusterConfigSchemaAttributes() map[string]schema.Attribute {
 				"schedule": schema.StringAttribute{
 					MarkdownDescription: "5-field UTC cron expression defining when the window opens, e.g. `0 2 * * *`. Required when `mode = CUSTOM`.",
 					Optional:            true,
+					Validators: []validator.String{
+						stringvalidator.LengthAtLeast(1),
+					},
 				},
 				"duration": schema.StringAttribute{
 					MarkdownDescription: "How long the window stays open, e.g. `30m` or `1h`. Required when `mode = CUSTOM`.",
 					Optional:            true,
+					Validators: []validator.String{
+						stringvalidator.LengthAtLeast(1),
+					},
 				},
 			},
 		},

--- a/internal/provider/cluster_config_common.go
+++ b/internal/provider/cluster_config_common.go
@@ -3,7 +3,9 @@ package provider
 import (
 	serverv1 "github.com/chalk-ai/chalk-go/gen/chalk/server/v1"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/objectvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -74,10 +76,19 @@ type maintenanceWindowModel struct {
 	Duration types.String `tfsdk:"duration"`
 }
 
+// dataPlaneRedisModel splits config by provisioning kind: exactly one of managed
+// or self_hosted is set, and the kind is derived from which one is present.
 type dataPlaneRedisModel struct {
-	Kind            types.String `tfsdk:"kind"`
-	Memory          types.String `tfsdk:"memory"`
-	Cpu             types.String `tfsdk:"cpu"`
+	Managed    *dataPlaneRedisManagedModel    `tfsdk:"managed"`
+	SelfHosted *dataPlaneRedisSelfHostedModel `tfsdk:"self_hosted"`
+}
+
+type dataPlaneRedisManagedModel struct {
+	Memory types.String `tfsdk:"memory"`
+	Cpu    types.String `tfsdk:"cpu"`
+}
+
+type dataPlaneRedisSelfHostedModel struct {
 	CloudSecretName types.String `tfsdk:"cloud_secret_name"`
 }
 
@@ -122,27 +133,42 @@ func clusterConfigSchemaAttributes() map[string]schema.Attribute {
 			},
 		},
 		"data_plane_redis": schema.SingleNestedAttribute{
-			MarkdownDescription: "Optional Redis instance for cluster operators to use as a shared cache.",
+			MarkdownDescription: "Optional Redis instance for cluster operators to use as a shared cache. Specify exactly one of `managed` or `self_hosted`.",
 			Optional:            true,
 			Attributes: map[string]schema.Attribute{
-				"kind": schema.StringAttribute{
-					MarkdownDescription: "Redis provisioning kind. `MANAGED` provisions a Chalk-managed instance. `SELF_HOSTED` is defined but not yet supported server-side.",
+				"managed": schema.SingleNestedAttribute{
+					MarkdownDescription: "Provision a Chalk-managed Redis instance.",
 					Optional:            true,
-					Validators: []validator.String{
-						stringvalidator.OneOf(dataPlaneRedisKindManaged, dataPlaneRedisKindSelfHosted),
+					Validators: []validator.Object{
+						objectvalidator.ExactlyOneOf(
+							path.MatchRelative().AtParent().AtName("self_hosted"),
+						),
+					},
+					Attributes: map[string]schema.Attribute{
+						"memory": schema.StringAttribute{
+							MarkdownDescription: "Memory size of the Redis instance, e.g. `1Gi`, `2Gi`.",
+							Optional:            true,
+						},
+						"cpu": schema.StringAttribute{
+							MarkdownDescription: "CPU size of the Redis instance, e.g. `500m`, `1`.",
+							Optional:            true,
+						},
 					},
 				},
-				"memory": schema.StringAttribute{
-					MarkdownDescription: "Memory size of the Redis instance, e.g. `1Gi`, `2Gi`.",
+				"self_hosted": schema.SingleNestedAttribute{
+					MarkdownDescription: "Use a self-hosted Redis instance. Defined for forward compatibility but not yet supported server-side.",
 					Optional:            true,
-				},
-				"cpu": schema.StringAttribute{
-					MarkdownDescription: "CPU size of the Redis instance, e.g. `500m`, `1`.",
-					Optional:            true,
-				},
-				"cloud_secret_name": schema.StringAttribute{
-					MarkdownDescription: "Name of the cloud secret holding credentials for a self-hosted Redis instance (only used when `kind = SELF_HOSTED`).",
-					Optional:            true,
+					Validators: []validator.Object{
+						objectvalidator.ExactlyOneOf(
+							path.MatchRelative().AtParent().AtName("managed"),
+						),
+					},
+					Attributes: map[string]schema.Attribute{
+						"cloud_secret_name": schema.StringAttribute{
+							MarkdownDescription: "Name of the cloud secret holding credentials for the self-hosted Redis instance.",
+							Required:            true,
+						},
+					},
 				},
 			},
 		},
@@ -226,11 +252,20 @@ func (m *dataPlaneRedisModel) toProto() *serverv1.DataPlaneRedis {
 	if m == nil {
 		return nil
 	}
+	if m.SelfHosted != nil {
+		kind := dataPlaneRedisKindSelfHosted
+		return &serverv1.DataPlaneRedis{
+			Kind:            &kind,
+			CloudSecretName: optionalStringPtr(m.SelfHosted.CloudSecretName),
+		}
+	}
+	// Exactly one of managed/self_hosted is set (enforced by schema validators),
+	// so reaching here means managed.
+	kind := dataPlaneRedisKindManaged
 	return &serverv1.DataPlaneRedis{
-		Kind:            optionalStringPtr(m.Kind),
-		Memory:          optionalStringPtr(m.Memory),
-		Cpu:             optionalStringPtr(m.Cpu),
-		CloudSecretName: optionalStringPtr(m.CloudSecretName),
+		Kind:   &kind,
+		Memory: optionalStringPtr(m.Managed.Memory),
+		Cpu:    optionalStringPtr(m.Managed.Cpu),
 	}
 }
 
@@ -275,11 +310,19 @@ func dataPlaneRedisFromProto(p *serverv1.DataPlaneRedis) *dataPlaneRedisModel {
 	if p == nil {
 		return nil
 	}
+	if p.GetKind() == dataPlaneRedisKindSelfHosted {
+		return &dataPlaneRedisModel{
+			SelfHosted: &dataPlaneRedisSelfHostedModel{
+				CloudSecretName: optionalStringValue(p.GetCloudSecretName()),
+			},
+		}
+	}
+	// The server treats an empty kind the same as MANAGED.
 	return &dataPlaneRedisModel{
-		Kind:            optionalStringValue(p.GetKind()),
-		Memory:          optionalStringValue(p.GetMemory()),
-		Cpu:             optionalStringValue(p.GetCpu()),
-		CloudSecretName: optionalStringValue(p.GetCloudSecretName()),
+		Managed: &dataPlaneRedisManagedModel{
+			Memory: optionalStringValue(p.GetMemory()),
+			Cpu:    optionalStringValue(p.GetCpu()),
+		},
 	}
 }
 

--- a/internal/provider/cluster_config_common.go
+++ b/internal/provider/cluster_config_common.go
@@ -1,0 +1,320 @@
+package provider
+
+import (
+	serverv1 "github.com/chalk-ai/chalk-go/gen/chalk/server/v1"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// This file holds the cluster-level configuration that both chalk_managed_cluster
+// and chalk_kubernetes_cluster expose on the CloudComponentCluster spec:
+// maintenance_window, data_plane_redis, and data_plane_controller. Both resources
+// share the schema, expand (model -> proto) and flatten (proto -> model) logic so
+// the two stay in lockstep.
+//
+// The server (go-api-server/cloudcomponents) treats all three blocks as the only
+// mutable spec fields, applying them identically for managed and unmanaged
+// clusters, which is why the config is common.
+
+// Maintenance window modes, exposed as short (prefix-stripped) tokens.
+const (
+	maintenanceModeUnspecified  = "UNSPECIFIED"
+	maintenanceModeUnrestricted = "UNRESTRICTED"
+	maintenanceModeCustom       = "CUSTOM"
+)
+
+// Data plane redis kinds. These are free-form strings the server matches
+// case-sensitively, so the tokens must match exactly (see
+// go-api-server/cloudcomponents/utils.go validateDataPlaneRedisSpec).
+const (
+	dataPlaneRedisKindManaged    = "MANAGED"
+	dataPlaneRedisKindSelfHosted = "SELF_HOSTED"
+)
+
+// Dataplane controller tiers, exposed as short (prefix-stripped) tokens.
+const (
+	dataPlaneControllerTierDisabled = "DISABLED"
+	dataPlaneControllerTierSmall    = "SMALL"
+	dataPlaneControllerTierMedium   = "MEDIUM"
+	dataPlaneControllerTierLarge    = "LARGE"
+)
+
+var maintenanceModeToProto = map[string]serverv1.MaintenanceWindow_Mode{
+	maintenanceModeUnspecified:  serverv1.MaintenanceWindow_MODE_UNSPECIFIED,
+	maintenanceModeUnrestricted: serverv1.MaintenanceWindow_MODE_UNRESTRICTED,
+	maintenanceModeCustom:       serverv1.MaintenanceWindow_MODE_CUSTOM,
+}
+
+var maintenanceModeFromProto = map[serverv1.MaintenanceWindow_Mode]string{
+	serverv1.MaintenanceWindow_MODE_UNSPECIFIED:  maintenanceModeUnspecified,
+	serverv1.MaintenanceWindow_MODE_UNRESTRICTED: maintenanceModeUnrestricted,
+	serverv1.MaintenanceWindow_MODE_CUSTOM:       maintenanceModeCustom,
+}
+
+var dataPlaneControllerTierToProto = map[string]serverv1.DataplaneController_Tier{
+	dataPlaneControllerTierDisabled: serverv1.DataplaneController_TIER_DISABLED,
+	dataPlaneControllerTierSmall:    serverv1.DataplaneController_TIER_SMALL,
+	dataPlaneControllerTierMedium:   serverv1.DataplaneController_TIER_MEDIUM,
+	dataPlaneControllerTierLarge:    serverv1.DataplaneController_TIER_LARGE,
+}
+
+var dataPlaneControllerTierFromProto = map[serverv1.DataplaneController_Tier]string{
+	serverv1.DataplaneController_TIER_DISABLED: dataPlaneControllerTierDisabled,
+	serverv1.DataplaneController_TIER_SMALL:    dataPlaneControllerTierSmall,
+	serverv1.DataplaneController_TIER_MEDIUM:   dataPlaneControllerTierMedium,
+	serverv1.DataplaneController_TIER_LARGE:    dataPlaneControllerTierLarge,
+}
+
+type maintenanceWindowModel struct {
+	Mode     types.String `tfsdk:"mode"`
+	Schedule types.String `tfsdk:"schedule"`
+	Duration types.String `tfsdk:"duration"`
+}
+
+type dataPlaneRedisModel struct {
+	Kind            types.String `tfsdk:"kind"`
+	Memory          types.String `tfsdk:"memory"`
+	Cpu             types.String `tfsdk:"cpu"`
+	CloudSecretName types.String `tfsdk:"cloud_secret_name"`
+}
+
+type dataPlaneControllerModel struct {
+	Tier               types.String    `tfsdk:"tier"`
+	NodePool           types.String    `tfsdk:"node_pool"`
+	RestrictedNodePool types.String    `tfsdk:"restricted_node_pool"`
+	HostPools          []hostPoolModel `tfsdk:"host_pools"`
+}
+
+type hostPoolModel struct {
+	Name   types.String `tfsdk:"name"`
+	Count  types.Int64  `tfsdk:"count"`
+	Cpu    types.String `tfsdk:"cpu"`
+	Memory types.String `tfsdk:"memory"`
+}
+
+// clusterConfigSchemaAttributes returns the shared cluster-level config
+// attributes to merge into a cluster resource's schema. All three blocks are
+// optional; omitting one leaves the corresponding spec field unset.
+func clusterConfigSchemaAttributes() map[string]schema.Attribute {
+	return map[string]schema.Attribute{
+		"maintenance_window": schema.SingleNestedAttribute{
+			MarkdownDescription: "Controls when disruptive maintenance operations may run on this cluster.",
+			Optional:            true,
+			Attributes: map[string]schema.Attribute{
+				"mode": schema.StringAttribute{
+					MarkdownDescription: "Maintenance scheduling mode. `UNSPECIFIED` uses the system default window, `UNRESTRICTED` allows operations at any time, and `CUSTOM` uses `schedule`/`duration`.",
+					Required:            true,
+					Validators: []validator.String{
+						stringvalidator.OneOf(maintenanceModeUnspecified, maintenanceModeUnrestricted, maintenanceModeCustom),
+					},
+				},
+				"schedule": schema.StringAttribute{
+					MarkdownDescription: "5-field UTC cron expression defining when the window opens, e.g. `0 2 * * *`. Required when `mode = CUSTOM`.",
+					Optional:            true,
+				},
+				"duration": schema.StringAttribute{
+					MarkdownDescription: "How long the window stays open, e.g. `30m` or `1h`. Required when `mode = CUSTOM`.",
+					Optional:            true,
+				},
+			},
+		},
+		"data_plane_redis": schema.SingleNestedAttribute{
+			MarkdownDescription: "Optional Redis instance for cluster operators to use as a shared cache.",
+			Optional:            true,
+			Attributes: map[string]schema.Attribute{
+				"kind": schema.StringAttribute{
+					MarkdownDescription: "Redis provisioning kind. `MANAGED` provisions a Chalk-managed instance. `SELF_HOSTED` is defined but not yet supported server-side.",
+					Optional:            true,
+					Validators: []validator.String{
+						stringvalidator.OneOf(dataPlaneRedisKindManaged, dataPlaneRedisKindSelfHosted),
+					},
+				},
+				"memory": schema.StringAttribute{
+					MarkdownDescription: "Memory size of the Redis instance, e.g. `1Gi`, `2Gi`.",
+					Optional:            true,
+				},
+				"cpu": schema.StringAttribute{
+					MarkdownDescription: "CPU size of the Redis instance, e.g. `500m`, `1`.",
+					Optional:            true,
+				},
+				"cloud_secret_name": schema.StringAttribute{
+					MarkdownDescription: "Name of the cloud secret holding credentials for a self-hosted Redis instance (only used when `kind = SELF_HOSTED`).",
+					Optional:            true,
+				},
+			},
+		},
+		"data_plane_controller": schema.SingleNestedAttribute{
+			MarkdownDescription: "Dataplane controller configuration, required to use Chalk Compute.",
+			Optional:            true,
+			Attributes: map[string]schema.Attribute{
+				"tier": schema.StringAttribute{
+					MarkdownDescription: "Resource tier for the dataplane controller. One of `DISABLED`, `SMALL`, `MEDIUM`, `LARGE`. Unset resolves to `SMALL` server-side.",
+					Optional:            true,
+					Validators: []validator.String{
+						stringvalidator.OneOf(dataPlaneControllerTierDisabled, dataPlaneControllerTierSmall, dataPlaneControllerTierMedium, dataPlaneControllerTierLarge),
+					},
+				},
+				"node_pool": schema.StringAttribute{
+					MarkdownDescription: "Node pool to pin non-gVisor (open) container/scaling-group workloads to.",
+					Optional:            true,
+				},
+				"restricted_node_pool": schema.StringAttribute{
+					MarkdownDescription: "Node pool to pin gVisor (restricted) container/scaling-group workloads to.",
+					Optional:            true,
+				},
+				"host_pools": schema.ListNestedAttribute{
+					MarkdownDescription: "Host pools to deploy for this cluster. Each entry provisions a ChalkHostPool.",
+					Optional:            true,
+					NestedObject: schema.NestedAttributeObject{
+						Attributes: map[string]schema.Attribute{
+							"name": schema.StringAttribute{
+								MarkdownDescription: "Name of the pool. Must be a valid DNS label.",
+								Required:            true,
+							},
+							"count": schema.Int64Attribute{
+								MarkdownDescription: "Number of hypervisor pods in the pool.",
+								Required:            true,
+								Validators: []validator.Int64{
+									int64validator.AtLeast(1),
+								},
+							},
+							"cpu": schema.StringAttribute{
+								MarkdownDescription: "CPU resources for each hypervisor pod, e.g. `4`.",
+								Optional:            true,
+							},
+							"memory": schema.StringAttribute{
+								MarkdownDescription: "Memory resources for each hypervisor pod, e.g. `8Gi`.",
+								Optional:            true,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// applyClusterConfigToSpec writes the three optional config blocks onto the
+// given spec. Nil models leave the corresponding spec field unset, which the
+// server interprets as "clear this config".
+func applyClusterConfigToSpec(
+	spec *serverv1.CloudComponentCluster,
+	maintenance *maintenanceWindowModel,
+	redis *dataPlaneRedisModel,
+	controller *dataPlaneControllerModel,
+) {
+	spec.MaintenanceWindow = maintenance.toProto()
+	spec.DataPlaneRedis = redis.toProto()
+	spec.DataplaneController = controller.toProto()
+}
+
+func (m *maintenanceWindowModel) toProto() *serverv1.MaintenanceWindow {
+	if m == nil {
+		return nil
+	}
+	return &serverv1.MaintenanceWindow{
+		Mode:     maintenanceModeToProto[m.Mode.ValueString()],
+		Schedule: m.Schedule.ValueString(),
+		Duration: m.Duration.ValueString(),
+	}
+}
+
+func (m *dataPlaneRedisModel) toProto() *serverv1.DataPlaneRedis {
+	if m == nil {
+		return nil
+	}
+	return &serverv1.DataPlaneRedis{
+		Kind:            optionalStringPtr(m.Kind),
+		Memory:          optionalStringPtr(m.Memory),
+		Cpu:             optionalStringPtr(m.Cpu),
+		CloudSecretName: optionalStringPtr(m.CloudSecretName),
+	}
+}
+
+func (m *dataPlaneControllerModel) toProto() *serverv1.DataplaneController {
+	if m == nil {
+		return nil
+	}
+	// available_tiers is output-only and is cleared server-side before persist,
+	// so it is intentionally never sent.
+	c := &serverv1.DataplaneController{
+		Tier:               dataPlaneControllerTierToProto[m.Tier.ValueString()],
+		NodePool:           optionalStringPtr(m.NodePool),
+		RestrictedNodePool: optionalStringPtr(m.RestrictedNodePool),
+	}
+	for _, pool := range m.HostPools {
+		c.HostPools = append(c.HostPools, &serverv1.ChalkHostPool{
+			Name:   pool.Name.ValueString(),
+			Count:  int32(pool.Count.ValueInt64()),
+			Cpu:    optionalStringPtr(pool.Cpu),
+			Memory: optionalStringPtr(pool.Memory),
+		})
+	}
+	return c
+}
+
+func maintenanceWindowFromProto(p *serverv1.MaintenanceWindow) *maintenanceWindowModel {
+	if p == nil {
+		return nil
+	}
+	mode, ok := maintenanceModeFromProto[p.GetMode()]
+	if !ok {
+		mode = maintenanceModeUnspecified
+	}
+	return &maintenanceWindowModel{
+		Mode:     types.StringValue(mode),
+		Schedule: optionalStringValue(p.GetSchedule()),
+		Duration: optionalStringValue(p.GetDuration()),
+	}
+}
+
+func dataPlaneRedisFromProto(p *serverv1.DataPlaneRedis) *dataPlaneRedisModel {
+	if p == nil {
+		return nil
+	}
+	return &dataPlaneRedisModel{
+		Kind:            optionalStringValue(p.GetKind()),
+		Memory:          optionalStringValue(p.GetMemory()),
+		Cpu:             optionalStringValue(p.GetCpu()),
+		CloudSecretName: optionalStringValue(p.GetCloudSecretName()),
+	}
+}
+
+func dataPlaneControllerFromProto(p *serverv1.DataplaneController) *dataPlaneControllerModel {
+	// The server always hydrates a non-nil DataplaneController on read to carry
+	// the output-only available_tiers (see hydrateOutputOnlyFields in
+	// go-api-server). Treat an otherwise-empty controller as unconfigured so a
+	// cluster with no controller block doesn't drift into a phantom object.
+	if p == nil || (p.GetTier() == serverv1.DataplaneController_TIER_UNSPECIFIED &&
+		p.GetNodePool() == "" && p.GetRestrictedNodePool() == "" && len(p.GetHostPools()) == 0) {
+		return nil
+	}
+	m := &dataPlaneControllerModel{
+		Tier:               optionalStringValue(dataPlaneControllerTierFromProto[p.GetTier()]),
+		NodePool:           optionalStringValue(p.GetNodePool()),
+		RestrictedNodePool: optionalStringValue(p.GetRestrictedNodePool()),
+	}
+	for _, pool := range p.GetHostPools() {
+		m.HostPools = append(m.HostPools, hostPoolModel{
+			Name:   types.StringValue(pool.GetName()),
+			Count:  types.Int64Value(int64(pool.GetCount())),
+			Cpu:    optionalStringValue(pool.GetCpu()),
+			Memory: optionalStringValue(pool.GetMemory()),
+		})
+	}
+	return m
+}
+
+// optionalStringPtr converts a types.String to a *string, returning nil for
+// null, unknown, or empty values so unset optional fields are omitted from the
+// proto rather than sent as empty strings.
+func optionalStringPtr(s types.String) *string {
+	if s.IsNull() || s.IsUnknown() || s.ValueString() == "" {
+		return nil
+	}
+	v := s.ValueString()
+	return &v
+}

--- a/internal/provider/helpers.go
+++ b/internal/provider/helpers.go
@@ -40,6 +40,20 @@ func optionalStringValue(s string) types.String {
 	return types.StringValue(s)
 }
 
+// stringPointerValue converts an optional (nullable) proto string to a
+// types.String using presence rather than emptiness: a nil pointer becomes null
+// and any non-nil pointer (including "") is preserved. Pair it with
+// types.String.ValueStringPointer() on the write side so a field round-trips
+// exactly, distinguishing "unset" from "explicitly empty". Only safe for proto
+// `optional string` fields whose presence the server round-trips faithfully; use
+// optionalStringValue when the server may return "" for unset fields.
+func stringPointerValue(p *string) types.String {
+	if p == nil {
+		return types.StringNull()
+	}
+	return types.StringValue(*p)
+}
+
 // kubeResourceConfigObject converts a KubeResourceConfig proto to a types.Object.
 func kubeResourceConfigObject(rc *serverv1.KubeResourceConfig) types.Object {
 	if rc == nil {

--- a/internal/provider/kubernetes_cluster_resource.go
+++ b/internal/provider/kubernetes_cluster_resource.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"maps"
 
 	"connectrpc.com/connect"
 	serverv1 "github.com/chalk-ai/chalk-go/gen/chalk/server/v1"
@@ -28,12 +29,15 @@ type KubernetesClusterResource struct {
 }
 
 type KubernetesClusterResourceModel struct {
-	Id                types.String `tfsdk:"id"`
-	Name              types.String `tfsdk:"name"`
-	Kind              types.String `tfsdk:"kind"`
-	CloudCredentialId types.String `tfsdk:"cloud_credential_id"`
-	DnsZone           types.String `tfsdk:"dns_zone"`
-	TeamId            types.String `tfsdk:"team_id"`
+	Id                  types.String              `tfsdk:"id"`
+	Name                types.String              `tfsdk:"name"`
+	Kind                types.String              `tfsdk:"kind"`
+	CloudCredentialId   types.String              `tfsdk:"cloud_credential_id"`
+	DnsZone             types.String              `tfsdk:"dns_zone"`
+	TeamId              types.String              `tfsdk:"team_id"`
+	MaintenanceWindow   *maintenanceWindowModel   `tfsdk:"maintenance_window"`
+	DataPlaneRedis      *dataPlaneRedisModel      `tfsdk:"data_plane_redis"`
+	DataPlaneController *dataPlaneControllerModel `tfsdk:"data_plane_controller"`
 }
 
 func (r *KubernetesClusterResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -86,6 +90,8 @@ func (r *KubernetesClusterResource) Schema(ctx context.Context, req resource.Sch
 			},
 		},
 	}
+
+	maps.Copy(resp.Schema.Attributes, clusterConfigSchemaAttributes())
 }
 
 func (r *KubernetesClusterResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
@@ -138,6 +144,8 @@ func (r *KubernetesClusterResource) Create(ctx context.Context, req resource.Cre
 		dnsZone := data.DnsZone.ValueString()
 		createReq.Cluster.Spec.DnsZone = &dnsZone
 	}
+
+	applyClusterConfigToSpec(createReq.Cluster.Spec, data.MaintenanceWindow, data.DataPlaneRedis, data.DataPlaneController)
 
 	cluster, err := cc.CreateCloudComponentCluster(ctx, connect.NewRequest(createReq))
 	if err != nil {
@@ -218,6 +226,8 @@ func (r *KubernetesClusterResource) Update(ctx context.Context, req resource.Upd
 		updateReq.Cluster.Spec.DnsZone = &dnsZone
 	}
 
+	applyClusterConfigToSpec(updateReq.Cluster.Spec, data.MaintenanceWindow, data.DataPlaneRedis, data.DataPlaneController)
+
 	cluster, err := cc.UpdateCloudComponentCluster(ctx, connect.NewRequest(updateReq))
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -262,4 +272,8 @@ func (r *KubernetesClusterResource) updateModelFromProto(model *KubernetesCluste
 	} else {
 		model.DnsZone = types.StringNull()
 	}
+
+	model.MaintenanceWindow = maintenanceWindowFromProto(cluster.Spec.GetMaintenanceWindow())
+	model.DataPlaneRedis = dataPlaneRedisFromProto(cluster.Spec.GetDataPlaneRedis())
+	model.DataPlaneController = dataPlaneControllerFromProto(cluster.Spec.GetDataplaneController())
 }

--- a/internal/provider/kubernetes_cluster_resource_test.go
+++ b/internal/provider/kubernetes_cluster_resource_test.go
@@ -47,8 +47,9 @@ resource "chalk_kubernetes_cluster" "cluster" {
 
 const kubeControllerBlockMedium = `
   data_plane_controller = {
-    tier      = "MEDIUM"
-    node_pool = "open-pool"
+    tier                 = "MEDIUM"
+    node_pool            = "open-pool"
+    restricted_node_pool = "restricted-pool"
     host_pools = [
       { name = "workers", count = 2, cpu = "4", memory = "8Gi" },
     ]
@@ -193,6 +194,7 @@ func TestKubernetesClusterResourceConfigRoundTrip(t *testing.T) {
 					resource.TestCheckResourceAttr("chalk_kubernetes_cluster.cluster", "data_plane_redis.managed.cpu", "1"),
 					resource.TestCheckResourceAttr("chalk_kubernetes_cluster.cluster", "data_plane_controller.tier", "MEDIUM"),
 					resource.TestCheckResourceAttr("chalk_kubernetes_cluster.cluster", "data_plane_controller.node_pool", "open-pool"),
+					resource.TestCheckResourceAttr("chalk_kubernetes_cluster.cluster", "data_plane_controller.restricted_node_pool", "restricted-pool"),
 					resource.TestCheckResourceAttr("chalk_kubernetes_cluster.cluster", "data_plane_controller.host_pools.#", "1"),
 					resource.TestCheckResourceAttr("chalk_kubernetes_cluster.cluster", "data_plane_controller.host_pools.0.name", "workers"),
 					resource.TestCheckResourceAttr("chalk_kubernetes_cluster.cluster", "data_plane_controller.host_pools.0.count", "2"),
@@ -221,6 +223,55 @@ func TestKubernetesClusterResourceConfigRoundTrip(t *testing.T) {
 					resource.TestCheckResourceAttr("chalk_kubernetes_cluster.cluster", "data_plane_controller.host_pools.1.name", "gpu"),
 					resource.TestCheckResourceAttr("chalk_kubernetes_cluster.cluster", "data_plane_controller.host_pools.1.machine_family", "n2"),
 				),
+			},
+		},
+	})
+}
+
+// TestKubernetesClusterResourceConfigClearOnUpdate verifies that removing the
+// config blocks from a cluster that had them clears them server-side (the update
+// sends nil blocks), the state drops them, and re-applying is a no-op.
+func TestKubernetesClusterResourceConfigClearOnUpdate(t *testing.T) {
+	t.Parallel()
+
+	server := setupClusterConfigServer(t, false)
+
+	withConfig := kubeClusterFullConfig(server.URL, kubeControllerBlockMedium, maintenanceModeCustom)
+	cleared := providerConfig(server.URL) + `
+resource "chalk_kubernetes_cluster" "cluster" {
+  name = "test-cluster"
+  kind = "EKS_STANDARD"
+}
+`
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: withConfig,
+				Check:  resource.TestCheckResourceAttr("chalk_kubernetes_cluster.cluster", "data_plane_controller.tier", "MEDIUM"),
+			},
+			{
+				Config: cleared,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr("chalk_kubernetes_cluster.cluster", "maintenance_window.mode"),
+					resource.TestCheckNoResourceAttr("chalk_kubernetes_cluster.cluster", "data_plane_redis.managed.memory"),
+					resource.TestCheckNoResourceAttr("chalk_kubernetes_cluster.cluster", "data_plane_controller.tier"),
+					func(s *terraform.State) error {
+						reqs := server.GetCapturedRequests("UpdateCloudComponentCluster")
+						require.GreaterOrEqual(t, len(reqs), 1)
+						spec := reqs[len(reqs)-1].(*serverv1.UpdateCloudComponentClusterRequest).Cluster.GetSpec()
+						assert.Nil(t, spec.GetMaintenanceWindow(), "update should clear maintenance_window")
+						assert.Nil(t, spec.GetDataPlaneRedis(), "update should clear data_plane_redis")
+						assert.Nil(t, spec.GetDataplaneController(), "update should clear data_plane_controller")
+						return nil
+					},
+				),
+			},
+			{
+				// Clearing must be stable: re-applying yields an empty plan.
+				Config:   cleared,
+				PlanOnly: true,
 			},
 		},
 	})

--- a/internal/provider/kubernetes_cluster_resource_test.go
+++ b/internal/provider/kubernetes_cluster_resource_test.go
@@ -60,7 +60,7 @@ const kubeControllerBlockLarge = `
     tier = "LARGE"
     host_pools = [
       { name = "workers", count = 3 },
-      { name = "gpu", count = 1, cpu = "8" },
+      { name = "gpu", count = 1, cpu = "8", machine_family = "n2" },
     ]
   }
 `
@@ -219,6 +219,7 @@ func TestKubernetesClusterResourceConfigRoundTrip(t *testing.T) {
 					resource.TestCheckNoResourceAttr("chalk_kubernetes_cluster.cluster", "data_plane_controller.node_pool"),
 					resource.TestCheckResourceAttr("chalk_kubernetes_cluster.cluster", "data_plane_controller.host_pools.#", "2"),
 					resource.TestCheckResourceAttr("chalk_kubernetes_cluster.cluster", "data_plane_controller.host_pools.1.name", "gpu"),
+					resource.TestCheckResourceAttr("chalk_kubernetes_cluster.cluster", "data_plane_controller.host_pools.1.machine_family", "n2"),
 				),
 			},
 		},

--- a/internal/provider/kubernetes_cluster_resource_test.go
+++ b/internal/provider/kubernetes_cluster_resource_test.go
@@ -298,6 +298,64 @@ resource "chalk_kubernetes_cluster" "cluster" {
 	})
 }
 
+// TestKubernetesClusterResourceDataPlaneControllerRejectsEmpty verifies that an
+// empty data_plane_controller block is rejected (it would otherwise drift to
+// null after apply).
+func TestKubernetesClusterResourceDataPlaneControllerRejectsEmpty(t *testing.T) {
+	t.Parallel()
+
+	server := setupClusterConfigServer(t, false)
+
+	config := providerConfig(server.URL) + `
+resource "chalk_kubernetes_cluster" "cluster" {
+  name = "test-cluster"
+  kind = "EKS_STANDARD"
+
+  data_plane_controller = {}
+}
+`
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config:      config,
+				ExpectError: regexp.MustCompile(`(?s)Invalid Attribute Combination|At least one attribute`),
+			},
+		},
+	})
+}
+
+// TestKubernetesClusterResourceHostPoolsRejectsEmptyList verifies that an empty
+// host_pools list is rejected in favor of omitting the attribute.
+func TestKubernetesClusterResourceHostPoolsRejectsEmptyList(t *testing.T) {
+	t.Parallel()
+
+	server := setupClusterConfigServer(t, false)
+
+	config := providerConfig(server.URL) + `
+resource "chalk_kubernetes_cluster" "cluster" {
+  name = "test-cluster"
+  kind = "EKS_STANDARD"
+
+  data_plane_controller = {
+    tier       = "SMALL"
+    host_pools = []
+  }
+}
+`
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config:      config,
+				ExpectError: regexp.MustCompile(`(?s)must contain at least 1`),
+			},
+		},
+	})
+}
+
 // TestKubernetesClusterResourceConfigOmittedNoDrift verifies that a cluster with
 // no data_plane_controller block does not drift even though the server hydrates
 // a non-nil (but empty) controller on every response.

--- a/internal/provider/kubernetes_cluster_resource_test.go
+++ b/internal/provider/kubernetes_cluster_resource_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"regexp"
 	"testing"
 
 	serverv1 "github.com/chalk-ai/chalk-go/gen/chalk/server/v1"
@@ -34,9 +35,10 @@ resource "chalk_kubernetes_cluster" "cluster" {
   }
 
   data_plane_redis = {
-    kind   = "MANAGED"
-    memory = "10Gi"
-    cpu    = "1"
+    managed = {
+      memory = "10Gi"
+      cpu    = "1"
+    }
   }
 ` + controllerBlock + `
 }
@@ -187,8 +189,8 @@ func TestKubernetesClusterResourceConfigRoundTrip(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("chalk_kubernetes_cluster.cluster", "maintenance_window.mode", "CUSTOM"),
 					resource.TestCheckResourceAttr("chalk_kubernetes_cluster.cluster", "maintenance_window.schedule", "0 2 * * *"),
-					resource.TestCheckResourceAttr("chalk_kubernetes_cluster.cluster", "data_plane_redis.kind", "MANAGED"),
-					resource.TestCheckResourceAttr("chalk_kubernetes_cluster.cluster", "data_plane_redis.memory", "10Gi"),
+					resource.TestCheckResourceAttr("chalk_kubernetes_cluster.cluster", "data_plane_redis.managed.memory", "10Gi"),
+					resource.TestCheckResourceAttr("chalk_kubernetes_cluster.cluster", "data_plane_redis.managed.cpu", "1"),
 					resource.TestCheckResourceAttr("chalk_kubernetes_cluster.cluster", "data_plane_controller.tier", "MEDIUM"),
 					resource.TestCheckResourceAttr("chalk_kubernetes_cluster.cluster", "data_plane_controller.node_pool", "open-pool"),
 					resource.TestCheckResourceAttr("chalk_kubernetes_cluster.cluster", "data_plane_controller.host_pools.#", "1"),
@@ -223,6 +225,78 @@ func TestKubernetesClusterResourceConfigRoundTrip(t *testing.T) {
 	})
 }
 
+// TestKubernetesClusterResourceDataPlaneRedisSelfHosted verifies the self_hosted
+// branch of the data_plane_redis one-of maps to kind SELF_HOSTED.
+func TestKubernetesClusterResourceDataPlaneRedisSelfHosted(t *testing.T) {
+	t.Parallel()
+
+	server := setupClusterConfigServer(t, false)
+
+	config := providerConfig(server.URL) + `
+resource "chalk_kubernetes_cluster" "cluster" {
+  name = "test-cluster"
+  kind = "EKS_STANDARD"
+
+  data_plane_redis = {
+    self_hosted = {
+      cloud_secret_name = "redis-creds"
+    }
+  }
+}
+`
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("chalk_kubernetes_cluster.cluster", "data_plane_redis.self_hosted.cloud_secret_name", "redis-creds"),
+					resource.TestCheckNoResourceAttr("chalk_kubernetes_cluster.cluster", "data_plane_redis.managed.memory"),
+					func(s *terraform.State) error {
+						reqs := server.GetCapturedRequests("CreateCloudComponentCluster")
+						require.Len(t, reqs, 1)
+						redis := reqs[0].(*serverv1.CreateCloudComponentClusterRequest).Cluster.GetSpec().GetDataPlaneRedis()
+						assert.Equal(t, "SELF_HOSTED", redis.GetKind())
+						assert.Equal(t, "redis-creds", redis.GetCloudSecretName())
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+// TestKubernetesClusterResourceDataPlaneRedisRequiresExactlyOne verifies that
+// setting both managed and self_hosted is rejected at plan time.
+func TestKubernetesClusterResourceDataPlaneRedisRequiresExactlyOne(t *testing.T) {
+	t.Parallel()
+
+	server := setupClusterConfigServer(t, false)
+
+	config := providerConfig(server.URL) + `
+resource "chalk_kubernetes_cluster" "cluster" {
+  name = "test-cluster"
+  kind = "EKS_STANDARD"
+
+  data_plane_redis = {
+    managed     = {}
+    self_hosted = { cloud_secret_name = "redis-creds" }
+  }
+}
+`
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config:      config,
+				ExpectError: regexp.MustCompile(`(?s)Invalid Attribute Combination`),
+			},
+		},
+	})
+}
+
 // TestKubernetesClusterResourceConfigOmittedNoDrift verifies that a cluster with
 // no data_plane_controller block does not drift even though the server hydrates
 // a non-nil (but empty) controller on every response.
@@ -246,7 +320,7 @@ resource "chalk_kubernetes_cluster" "cluster" {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckNoResourceAttr("chalk_kubernetes_cluster.cluster", "data_plane_controller.tier"),
 					resource.TestCheckNoResourceAttr("chalk_kubernetes_cluster.cluster", "maintenance_window.mode"),
-					resource.TestCheckNoResourceAttr("chalk_kubernetes_cluster.cluster", "data_plane_redis.kind"),
+					resource.TestCheckNoResourceAttr("chalk_kubernetes_cluster.cluster", "data_plane_redis.managed.memory"),
 				),
 			},
 			{

--- a/internal/provider/kubernetes_cluster_resource_test.go
+++ b/internal/provider/kubernetes_cluster_resource_test.go
@@ -1,0 +1,260 @@
+package provider
+
+import (
+	"testing"
+
+	serverv1 "github.com/chalk-ai/chalk-go/gen/chalk/server/v1"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func kubeClusterCoreConfig(serverURL, dnsZone string) string {
+	return providerConfig(serverURL) + `
+resource "chalk_kubernetes_cluster" "cluster" {
+  name                = "test-cluster"
+  kind                = "EKS_STANDARD"
+  cloud_credential_id = "cc-test-id"
+  dns_zone            = "` + dnsZone + `"
+}
+`
+}
+
+func kubeClusterFullConfig(serverURL, controllerBlock, maintenanceMode string) string {
+	return providerConfig(serverURL) + `
+resource "chalk_kubernetes_cluster" "cluster" {
+  name = "test-cluster"
+  kind = "EKS_STANDARD"
+
+  maintenance_window = {
+    mode     = "` + maintenanceMode + `"
+    schedule = "0 2 * * *"
+    duration = "30m"
+  }
+
+  data_plane_redis = {
+    kind   = "MANAGED"
+    memory = "10Gi"
+    cpu    = "1"
+  }
+` + controllerBlock + `
+}
+`
+}
+
+const kubeControllerBlockMedium = `
+  data_plane_controller = {
+    tier      = "MEDIUM"
+    node_pool = "open-pool"
+    host_pools = [
+      { name = "workers", count = 2, cpu = "4", memory = "8Gi" },
+    ]
+  }
+`
+
+const kubeControllerBlockLarge = `
+  data_plane_controller = {
+    tier = "LARGE"
+    host_pools = [
+      { name = "workers", count = 3 },
+      { name = "gpu", count = 1, cpu = "8" },
+    ]
+  }
+`
+
+// TestKubernetesClusterResourceCreateRead verifies the core create/read
+// round-trip for the unmanaged cluster resource.
+func TestKubernetesClusterResourceCreateRead(t *testing.T) {
+	t.Parallel()
+
+	server := setupClusterConfigServer(t, false)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: kubeClusterCoreConfig(server.URL, "example.com"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("chalk_kubernetes_cluster.cluster", "id", "cluster-cfg-id"),
+					resource.TestCheckResourceAttr("chalk_kubernetes_cluster.cluster", "name", "test-cluster"),
+					resource.TestCheckResourceAttr("chalk_kubernetes_cluster.cluster", "kind", "EKS_STANDARD"),
+					resource.TestCheckResourceAttr("chalk_kubernetes_cluster.cluster", "cloud_credential_id", "cc-test-id"),
+					resource.TestCheckResourceAttr("chalk_kubernetes_cluster.cluster", "dns_zone", "example.com"),
+					resource.TestCheckResourceAttr("chalk_kubernetes_cluster.cluster", "team_id", "team-test-id"),
+					func(s *terraform.State) error {
+						reqs := server.GetCapturedRequests("CreateCloudComponentCluster")
+						require.Len(t, reqs, 1)
+						r := reqs[0].(*serverv1.CreateCloudComponentClusterRequest)
+						assert.False(t, r.Cluster.GetManaged(), "kubernetes_cluster must be unmanaged")
+						assert.Equal(t, "test-cluster", r.Cluster.GetSpec().GetName())
+						assert.Equal(t, "example.com", r.Cluster.GetSpec().GetDnsZone())
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+// TestKubernetesClusterResourceUpdateDnsZone verifies that mutating dns_zone
+// issues an update and reads back the new value.
+func TestKubernetesClusterResourceUpdateDnsZone(t *testing.T) {
+	t.Parallel()
+
+	server := setupClusterConfigServer(t, false)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: kubeClusterCoreConfig(server.URL, "example.com"),
+				Check:  resource.TestCheckResourceAttr("chalk_kubernetes_cluster.cluster", "dns_zone", "example.com"),
+			},
+			{
+				Config: kubeClusterCoreConfig(server.URL, "updated.example.com"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("chalk_kubernetes_cluster.cluster", "dns_zone", "updated.example.com"),
+					func(s *terraform.State) error {
+						reqs := server.GetCapturedRequests("UpdateCloudComponentCluster")
+						require.GreaterOrEqual(t, len(reqs), 1)
+						spec := reqs[len(reqs)-1].(*serverv1.UpdateCloudComponentClusterRequest).Cluster.GetSpec()
+						assert.Equal(t, "updated.example.com", spec.GetDnsZone())
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+// TestKubernetesClusterResourceDeleteIsNoOp verifies that removing the resource
+// only drops it from state and never calls DeleteCloudComponentCluster, since
+// the underlying cluster is unmanaged.
+func TestKubernetesClusterResourceDeleteIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	server := setupClusterConfigServer(t, false)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{Config: kubeClusterCoreConfig(server.URL, "example.com")},
+			{
+				Config: providerConfig(server.URL),
+				Check: func(s *terraform.State) error {
+					assert.Empty(t, server.GetCapturedRequests("DeleteCloudComponentCluster"),
+						"unmanaged cluster delete must not call the server")
+					return nil
+				},
+			},
+		},
+	})
+}
+
+// TestKubernetesClusterResourceImportState verifies import by cluster id.
+func TestKubernetesClusterResourceImportState(t *testing.T) {
+	t.Parallel()
+
+	server := setupClusterConfigServer(t, false)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{Config: kubeClusterCoreConfig(server.URL, "example.com")},
+			{
+				ResourceName:      "chalk_kubernetes_cluster.cluster",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// TestKubernetesClusterResourceConfigRoundTrip verifies that the shared
+// cluster-level config blocks are sent on create, read back consistently, and
+// mutated on update.
+func TestKubernetesClusterResourceConfigRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	server := setupClusterConfigServer(t, false)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: kubeClusterFullConfig(server.URL, kubeControllerBlockMedium, maintenanceModeCustom),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("chalk_kubernetes_cluster.cluster", "maintenance_window.mode", "CUSTOM"),
+					resource.TestCheckResourceAttr("chalk_kubernetes_cluster.cluster", "maintenance_window.schedule", "0 2 * * *"),
+					resource.TestCheckResourceAttr("chalk_kubernetes_cluster.cluster", "data_plane_redis.kind", "MANAGED"),
+					resource.TestCheckResourceAttr("chalk_kubernetes_cluster.cluster", "data_plane_redis.memory", "10Gi"),
+					resource.TestCheckResourceAttr("chalk_kubernetes_cluster.cluster", "data_plane_controller.tier", "MEDIUM"),
+					resource.TestCheckResourceAttr("chalk_kubernetes_cluster.cluster", "data_plane_controller.node_pool", "open-pool"),
+					resource.TestCheckResourceAttr("chalk_kubernetes_cluster.cluster", "data_plane_controller.host_pools.#", "1"),
+					resource.TestCheckResourceAttr("chalk_kubernetes_cluster.cluster", "data_plane_controller.host_pools.0.name", "workers"),
+					resource.TestCheckResourceAttr("chalk_kubernetes_cluster.cluster", "data_plane_controller.host_pools.0.count", "2"),
+					func(s *terraform.State) error {
+						reqs := server.GetCapturedRequests("CreateCloudComponentCluster")
+						require.Len(t, reqs, 1)
+						spec := reqs[0].(*serverv1.CreateCloudComponentClusterRequest).Cluster.GetSpec()
+						assert.Equal(t, serverv1.MaintenanceWindow_MODE_CUSTOM, spec.GetMaintenanceWindow().GetMode())
+						assert.Equal(t, "MANAGED", spec.GetDataPlaneRedis().GetKind())
+						assert.Equal(t, serverv1.DataplaneController_TIER_MEDIUM, spec.GetDataplaneController().GetTier())
+						require.Len(t, spec.GetDataplaneController().GetHostPools(), 1)
+						assert.Equal(t, int32(2), spec.GetDataplaneController().GetHostPools()[0].GetCount())
+						// available_tiers is output-only and must never be sent.
+						assert.Nil(t, spec.GetDataplaneController().GetAvailableTiers())
+						return nil
+					},
+				),
+			},
+			{
+				Config: kubeClusterFullConfig(server.URL, kubeControllerBlockLarge, maintenanceModeUnrestricted),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("chalk_kubernetes_cluster.cluster", "maintenance_window.mode", "UNRESTRICTED"),
+					resource.TestCheckResourceAttr("chalk_kubernetes_cluster.cluster", "data_plane_controller.tier", "LARGE"),
+					resource.TestCheckNoResourceAttr("chalk_kubernetes_cluster.cluster", "data_plane_controller.node_pool"),
+					resource.TestCheckResourceAttr("chalk_kubernetes_cluster.cluster", "data_plane_controller.host_pools.#", "2"),
+					resource.TestCheckResourceAttr("chalk_kubernetes_cluster.cluster", "data_plane_controller.host_pools.1.name", "gpu"),
+				),
+			},
+		},
+	})
+}
+
+// TestKubernetesClusterResourceConfigOmittedNoDrift verifies that a cluster with
+// no data_plane_controller block does not drift even though the server hydrates
+// a non-nil (but empty) controller on every response.
+func TestKubernetesClusterResourceConfigOmittedNoDrift(t *testing.T) {
+	t.Parallel()
+
+	server := setupClusterConfigServer(t, false)
+
+	config := providerConfig(server.URL) + `
+resource "chalk_kubernetes_cluster" "cluster" {
+  name = "test-cluster"
+  kind = "EKS_STANDARD"
+}
+`
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr("chalk_kubernetes_cluster.cluster", "data_plane_controller.tier"),
+					resource.TestCheckNoResourceAttr("chalk_kubernetes_cluster.cluster", "maintenance_window.mode"),
+					resource.TestCheckNoResourceAttr("chalk_kubernetes_cluster.cluster", "data_plane_redis.kind"),
+				),
+			},
+			{
+				// Re-applying the identical config must produce an empty plan: the
+				// hydrated controller must not surface as a phantom object.
+				Config:   config,
+				PlanOnly: true,
+			},
+		},
+	})
+}

--- a/internal/provider/kubernetes_cluster_resource_test.go
+++ b/internal/provider/kubernetes_cluster_resource_test.go
@@ -356,6 +356,43 @@ resource "chalk_kubernetes_cluster" "cluster" {
 	})
 }
 
+// TestKubernetesClusterResourceOptionalEmptyStringRoundTrip verifies that an
+// optional string set to an explicit "" round-trips without drift. Presence-aware
+// flatten distinguishes "unset" (null) from "explicitly empty" (""); a value-based
+// flatten would collapse "" to null and error with an inconsistent result.
+func TestKubernetesClusterResourceOptionalEmptyStringRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	server := setupClusterConfigServer(t, false)
+
+	config := providerConfig(server.URL) + `
+resource "chalk_kubernetes_cluster" "cluster" {
+  name = "test-cluster"
+  kind = "EKS_STANDARD"
+
+  data_plane_controller = {
+    tier      = "SMALL"
+    node_pool = ""
+  }
+}
+`
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check:  resource.TestCheckResourceAttr("chalk_kubernetes_cluster.cluster", "data_plane_controller.node_pool", ""),
+			},
+			{
+				// Re-applying must be a no-op: "" must not drift to null.
+				Config:   config,
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 // TestKubernetesClusterResourceConfigOmittedNoDrift verifies that a cluster with
 // no data_plane_controller block does not drift even though the server hydrates
 // a non-nil (but empty) controller on every response.

--- a/internal/provider/kubernetes_cluster_resource_test.go
+++ b/internal/provider/kubernetes_cluster_resource_test.go
@@ -356,10 +356,43 @@ resource "chalk_kubernetes_cluster" "cluster" {
 	})
 }
 
+// TestKubernetesClusterResourceMaintenanceEmptyStringRejected verifies that an
+// empty schedule is rejected at plan time. schedule/duration are plain proto
+// strings with no presence bit, so "" is indistinguishable from unset and would
+// drift; it's forbidden rather than allowed.
+func TestKubernetesClusterResourceMaintenanceEmptyStringRejected(t *testing.T) {
+	t.Parallel()
+
+	server := setupClusterConfigServer(t, false)
+
+	config := providerConfig(server.URL) + `
+resource "chalk_kubernetes_cluster" "cluster" {
+  name = "test-cluster"
+  kind = "EKS_STANDARD"
+
+  maintenance_window = {
+    mode     = "CUSTOM"
+    schedule = ""
+    duration = "30m"
+  }
+}
+`
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config:      config,
+				ExpectError: regexp.MustCompile(`(?s)string length must be at least 1`),
+			},
+		},
+	})
+}
+
 // TestKubernetesClusterResourceOptionalEmptyStringRoundTrip verifies that an
-// optional string set to an explicit "" round-trips without drift. Presence-aware
-// flatten distinguishes "unset" (null) from "explicitly empty" (""); a value-based
-// flatten would collapse "" to null and error with an inconsistent result.
+// optional (pointer) string set to an explicit "" round-trips without drift.
+// Presence-aware flatten distinguishes "unset" (null) from "explicitly empty"
+// (""); a value-based flatten would collapse "" to null and error.
 func TestKubernetesClusterResourceOptionalEmptyStringRoundTrip(t *testing.T) {
 	t.Parallel()
 

--- a/internal/provider/managed_cluster_resource.go
+++ b/internal/provider/managed_cluster_resource.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"maps"
 	"time"
 
 	"connectrpc.com/connect"
@@ -45,12 +46,15 @@ type ManagedClusterResource struct {
 }
 
 type ManagedClusterResourceModel struct {
-	Id                types.String `tfsdk:"id"`
-	Name              types.String `tfsdk:"name"`
-	Kind              types.String `tfsdk:"kind"`
-	Designator        types.String `tfsdk:"designator"`
-	CloudCredentialId types.String `tfsdk:"cloud_credential_id"`
-	VpcId             types.String `tfsdk:"vpc_id"`
+	Id                  types.String              `tfsdk:"id"`
+	Name                types.String              `tfsdk:"name"`
+	Kind                types.String              `tfsdk:"kind"`
+	Designator          types.String              `tfsdk:"designator"`
+	CloudCredentialId   types.String              `tfsdk:"cloud_credential_id"`
+	VpcId               types.String              `tfsdk:"vpc_id"`
+	MaintenanceWindow   *maintenanceWindowModel   `tfsdk:"maintenance_window"`
+	DataPlaneRedis      *dataPlaneRedisModel      `tfsdk:"data_plane_redis"`
+	DataPlaneController *dataPlaneControllerModel `tfsdk:"data_plane_controller"`
 }
 
 func (r *ManagedClusterResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -106,6 +110,8 @@ func (r *ManagedClusterResource) Schema(ctx context.Context, req resource.Schema
 			},
 		},
 	}
+
+	maps.Copy(resp.Schema.Attributes, clusterConfigSchemaAttributes())
 }
 
 func (r *ManagedClusterResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
@@ -147,8 +153,13 @@ func (r *ManagedClusterResource) Create(ctx context.Context, req resource.Create
 			Managed:           true,
 			CloudCredentialId: &credentialId,
 			VpcId:             &vpcId,
+			// The server generates name/kind/designator/dns for managed clusters,
+			// but still reads the config blocks off the spec.
+			Spec: &serverv1.CloudComponentCluster{},
 		},
 	}
+
+	applyClusterConfigToSpec(createReq.Cluster.Spec, data.MaintenanceWindow, data.DataPlaneRedis, data.DataPlaneController)
 
 	cluster, err := cc.CreateCloudComponentCluster(ctx, connect.NewRequest(createReq))
 	if err != nil {
@@ -217,8 +228,10 @@ func (r *ManagedClusterResource) Read(ctx context.Context, req resource.ReadRequ
 }
 
 func (r *ManagedClusterResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	// Since cloud_credential_id has RequiresReplace, updates should only happen
-	// for computed fields which we don't modify. Just refresh state from server.
+	// cloud_credential_id and vpc_id are RequiresReplace, so the only mutable
+	// fields are the cluster-level config blocks. Push them via a spec update; the
+	// server overlays them onto the stored spec and applies the change
+	// synchronously, returning the updated cluster.
 	var data ManagedClusterResourceModel
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
@@ -230,18 +243,25 @@ func (r *ManagedClusterResource) Update(ctx context.Context, req resource.Update
 	// Create cloud components client
 	cc := r.client.NewCloudComponentsClient(ctx)
 
-	cluster, err := cc.GetCloudComponentCluster(ctx, connect.NewRequest(&serverv1.GetCloudComponentClusterRequest{
+	updateReq := &serverv1.UpdateCloudComponentClusterRequest{
 		Id: data.Id.ValueString(),
-	}))
+		Cluster: &serverv1.CloudComponentClusterRequest{
+			Managed: true,
+			Spec:    &serverv1.CloudComponentCluster{},
+		},
+	}
+	applyClusterConfigToSpec(updateReq.Cluster.Spec, data.MaintenanceWindow, data.DataPlaneRedis, data.DataPlaneController)
+
+	cluster, err := cc.UpdateCloudComponentCluster(ctx, connect.NewRequest(updateReq))
 	if err != nil {
 		resp.Diagnostics.AddError(
-			"Error Reading Managed Cluster",
-			fmt.Sprintf("Could not read managed cluster %s: %v", data.Id.ValueString(), err),
+			"Error Updating Managed Cluster",
+			fmt.Sprintf("Could not update managed cluster %s: %v", data.Id.ValueString(), err),
 		)
 		return
 	}
 
-	// Update the model with the fetched data
+	// Update the model with the returned data
 	r.updateModelFromProto(&data, cluster.Msg.Cluster)
 
 	tflog.Trace(ctx, "updated chalk_managed_cluster resource")
@@ -369,4 +389,8 @@ func (r *ManagedClusterResource) updateModelFromProto(model *ManagedClusterResou
 	} else {
 		model.VpcId = types.StringNull()
 	}
+
+	model.MaintenanceWindow = maintenanceWindowFromProto(cluster.Spec.GetMaintenanceWindow())
+	model.DataPlaneRedis = dataPlaneRedisFromProto(cluster.Spec.GetDataPlaneRedis())
+	model.DataPlaneController = dataPlaneControllerFromProto(cluster.Spec.GetDataplaneController())
 }

--- a/internal/provider/managed_cluster_resource_test.go
+++ b/internal/provider/managed_cluster_resource_test.go
@@ -15,13 +15,7 @@ import (
 )
 
 // setupClusterConfigServer wires the cloud-component cluster RPCs to registry
-// mocks that echo back the last spec written by Create/Update. Get must reflect
-// the latest config so the acceptance framework's post-apply refresh sees an
-// empty plan across update steps. Every response hydrates a non-nil
-// DataplaneController the way go-api-server's hydrateOutputOnlyFields does, so
-// the tests exercise the provider's guard against that output-only field
-// surfacing as drift. It is shared by the managed and unmanaged cluster tests
-// since both drive the same CloudComponentCluster spec.
+// mocks that echo back the last spec written by Create/Update.
 func setupClusterConfigServer(t *testing.T, managed bool) *testserver.MockServer {
 	server := testserver.NewMockBuilderServer(t)
 	t.Cleanup(func() { server.Close() })
@@ -300,8 +294,7 @@ func TestManagedClusterResourceDeleteWaitsForDeleting(t *testing.T) {
 }
 
 // TestManagedClusterResourceConfigUpdate verifies that the managed cluster
-// resource sends the cluster-level config on create and pushes a real
-// UpdateCloudComponentCluster (rather than a no-op read) when the config changes.
+// resource sends the cluster-level config on create.
 func TestManagedClusterResourceConfigUpdate(t *testing.T) {
 	t.Parallel()
 

--- a/internal/provider/managed_cluster_resource_test.go
+++ b/internal/provider/managed_cluster_resource_test.go
@@ -14,6 +14,91 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+// setupClusterConfigServer wires the cloud-component cluster RPCs to registry
+// mocks that echo back the last spec written by Create/Update. Get must reflect
+// the latest config so the acceptance framework's post-apply refresh sees an
+// empty plan across update steps. Every response hydrates a non-nil
+// DataplaneController the way go-api-server's hydrateOutputOnlyFields does, so
+// the tests exercise the provider's guard against that output-only field
+// surfacing as drift. It is shared by the managed and unmanaged cluster tests
+// since both drive the same CloudComponentCluster spec.
+func setupClusterConfigServer(t *testing.T, managed bool) *testserver.MockServer {
+	server := testserver.NewMockBuilderServer(t)
+	t.Cleanup(func() { server.Close() })
+
+	// The acceptance test runs serially, so no synchronization is needed.
+	var (
+		stored  *serverv1.CloudComponentCluster
+		kind    string
+		ccID    *string
+		vpc     *string
+		deleted bool
+	)
+
+	response := func() *serverv1.CloudComponentClusterResponse {
+		spec := proto.Clone(stored).(*serverv1.CloudComponentCluster)
+		if spec.DataplaneController == nil {
+			spec.DataplaneController = &serverv1.DataplaneController{}
+		}
+		spec.DataplaneController.AvailableTiers = []*serverv1.DataplaneController_TierInfo{
+			{Tier: serverv1.DataplaneController_TIER_SMALL},
+		}
+		return &serverv1.CloudComponentClusterResponse{
+			Id:                "cluster-cfg-id",
+			Kind:              kind,
+			Managed:           managed,
+			CloudCredentialId: ccID,
+			VpcId:             vpc,
+			TeamId:            "team-test-id",
+			Status:            "ACTIVE",
+			Designator:        spec.Designator,
+			Spec:              spec,
+		}
+	}
+
+	server.OnCreateCloudComponentCluster().WithBehavior(func(req proto.Message) (proto.Message, error) {
+		r := req.(*serverv1.CreateCloudComponentClusterRequest)
+		stored = proto.Clone(r.Cluster.GetSpec()).(*serverv1.CloudComponentCluster)
+		kind = r.Cluster.GetKind()
+		ccID = r.Cluster.CloudCredentialId
+		vpc = r.Cluster.VpcId
+		if stored.GetName() == "" {
+			// Managed clusters have name/kind/designator generated server-side.
+			stored.Name = "managed-test-cluster"
+			stored.Designator = new("abcd")
+			kind = "EKS_STANDARD"
+		}
+		return &serverv1.CreateCloudComponentClusterResponse{Cluster: response()}, nil
+	})
+
+	server.OnGetCloudComponentCluster().WithBehavior(func(req proto.Message) (proto.Message, error) {
+		// The managed resource's Delete polls until the cluster is gone.
+		if deleted {
+			return nil, notFound("cluster not found")
+		}
+		return &serverv1.GetCloudComponentClusterResponse{Cluster: response()}, nil
+	})
+
+	server.OnUpdateCloudComponentCluster().WithBehavior(func(req proto.Message) (proto.Message, error) {
+		// Mirror the server: only the config blocks (+ dns_zone) are mutable.
+		reqSpec := req.(*serverv1.UpdateCloudComponentClusterRequest).Cluster.GetSpec()
+		stored.DataPlaneRedis = reqSpec.GetDataPlaneRedis()
+		stored.DataplaneController = reqSpec.GetDataplaneController()
+		stored.MaintenanceWindow = reqSpec.GetMaintenanceWindow()
+		if reqSpec.DnsZone != nil {
+			stored.DnsZone = reqSpec.DnsZone
+		}
+		return &serverv1.UpdateCloudComponentClusterResponse{Cluster: response()}, nil
+	})
+
+	server.OnDeleteCloudComponentCluster().WithBehavior(func(req proto.Message) (proto.Message, error) {
+		deleted = true
+		return &serverv1.DeleteCloudComponentClusterResponse{}, nil
+	})
+
+	return server
+}
+
 // clusterResponse builds a CloudComponentClusterResponse with the given
 // lifecycle status (and optional status_error).
 func clusterResponse(status string, statusErr string) *serverv1.CloudComponentClusterResponse {
@@ -209,6 +294,65 @@ func TestManagedClusterResourceDeleteWaitsForDeleting(t *testing.T) {
 					assert.GreaterOrEqual(t, int(deleteGets.Load()), 3, "expected Delete to keep polling through DELETING")
 					return nil
 				},
+			},
+		},
+	})
+}
+
+// TestManagedClusterResourceConfigUpdate verifies that the managed cluster
+// resource sends the cluster-level config on create and pushes a real
+// UpdateCloudComponentCluster (rather than a no-op read) when the config changes.
+func TestManagedClusterResourceConfigUpdate(t *testing.T) {
+	t.Parallel()
+
+	server := setupClusterConfigServer(t, true)
+
+	config := func(tier string) string {
+		return providerConfig(server.URL) + `
+resource "chalk_managed_cluster" "cluster" {
+  cloud_credential_id = "cc-test-id"
+  vpc_id              = "vpc-test-id"
+
+  maintenance_window = {
+    mode = "UNRESTRICTED"
+  }
+
+  data_plane_controller = {
+    tier = "` + tier + `"
+  }
+}
+`
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: config("SMALL"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("chalk_managed_cluster.cluster", "data_plane_controller.tier", "SMALL"),
+					resource.TestCheckResourceAttr("chalk_managed_cluster.cluster", "maintenance_window.mode", "UNRESTRICTED"),
+					func(s *terraform.State) error {
+						reqs := server.GetCapturedRequests("CreateCloudComponentCluster")
+						require.Len(t, reqs, 1)
+						spec := reqs[0].(*serverv1.CreateCloudComponentClusterRequest).Cluster.GetSpec()
+						assert.Equal(t, serverv1.DataplaneController_TIER_SMALL, spec.GetDataplaneController().GetTier())
+						return nil
+					},
+				),
+			},
+			{
+				Config: config("MEDIUM"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("chalk_managed_cluster.cluster", "data_plane_controller.tier", "MEDIUM"),
+					func(s *terraform.State) error {
+						reqs := server.GetCapturedRequests("UpdateCloudComponentCluster")
+						require.GreaterOrEqual(t, len(reqs), 1)
+						spec := reqs[len(reqs)-1].(*serverv1.UpdateCloudComponentClusterRequest).Cluster.GetSpec()
+						assert.Equal(t, serverv1.DataplaneController_TIER_MEDIUM, spec.GetDataplaneController().GetTier())
+						return nil
+					},
+				),
 			},
 		},
 	})


### PR DESCRIPTION
## Summary

Exposes cluster-level config for both `chalk_managed_cluster` and `chalk_kubernetes_cluster`:

- `maintenance_window`
- `data_plane_redis`
- `data_plane_controller`

## Details

- **`cluster_config_common.go`** (new): shared models, schema, expand/flatten, and enum maps for the three blocks, used by both resources. Includes a guard so the server's output-only `DataplaneController` hydration (`hydrateOutputOnlyFields`) doesn't surface as phantom drift.
- Wired config into both resources' Create/Update/flatten. The managed resource's `Update` was previously a no-op read and now issues a real `UpdateCloudComponentCluster`.
- Brought the previously-untested `chalk_kubernetes_cluster` resource to test parity (create/read, update, no-op delete, import) plus config round-trip and drift-guard coverage; added a managed config-update test.
- Regenerated docs.

## Notes

- `data_plane_redis.kind = "SELF_HOSTED"` is accepted at plan time (proto-aligned, documented) but currently rejected server-side at apply — chosen for forward-compatibility.
- E2E test for provider with these changes fails due to drift - E2E environment has some of the config being added in this change set; will align after merge and release. Validated no drift without these set on remotedev as well as basic validation of set-update-clear workflows.