### PR TITLE
Make cloud_credential_id Optional for unmanaged cloud storage

### DIFF
--- a/docs/resources/unmanaged_cloud_storage.md
+++ b/docs/resources/unmanaged_cloud_storage.md
@@ -37,11 +37,11 @@ resource "chalk_unmanaged_cloud_storage" "datasets" {
 
 ### Required
 
-- `cloud_credential_id` (String) ID of the cloud credential (e.g. a `chalk_aws_cloud_credentials`/`chalk_gcp_cloud_credentials`/`chalk_azure_cloud_credentials` resource) used to access the bucket. Changing this forces a new resource.
 - `uri` (String) URI of the existing bucket (and optional path prefix), e.g. `s3://bucket/prefix`, `gs://bucket/prefix`, or `abfs://<account>.blob.core.windows.net/<container>[/path]`. When `kind` is set, the scheme must match it. Changing this forces a new resource.
 
 ### Optional
 
+- `cloud_credential_id` (String) ID of the cloud credential (e.g. a `chalk_aws_cloud_credentials`/`chalk_gcp_cloud_credentials`/`chalk_azure_cloud_credentials` resource) used to access the bucket. Optional for unmanaged storage: omit it when the bucket is reached via workload identity / instance IAM rather than an explicit Chalk credential (an imported bucket with no credential reads back null). Changing this forces a new resource.
 - `kind` (String) Cloud storage kind. One of `gcs`, `s3`, or `abs` (Azure Blob Storage). Optional: when omitted, Chalk infers it from the cloud credential. Changing this forces a new resource.
 
 ### Read-Only

--- a/internal/provider/cloud_storage_common.go
+++ b/internal/provider/cloud_storage_common.go
@@ -68,6 +68,7 @@ type cloudStorageResourceModel struct {
 func cloudStorageSchema(managed bool) schema.Schema {
 	var markdown string
 	var uriAttr schema.StringAttribute
+	var credAttr schema.StringAttribute
 	if managed {
 		markdown = "Registers a Chalk-managed cloud storage: Chalk owns the bucket and derives its `uri`, so you only supply the cloud credential.\n\n" +
 			"Every attribute is replace-only (there is no update RPC). **Create-time bucket access check:** creating this resource performs a live access check using the referenced `cloud_credential_id`; apply fails unless that credential can reach the storage, so the credential must exist first."
@@ -77,6 +78,11 @@ func cloudStorageSchema(managed bool) schema.Schema {
 			PlanModifiers: []planmodifier.String{
 				stringplanmodifier.UseStateForUnknown(),
 			},
+		}
+		credAttr = schema.StringAttribute{
+			MarkdownDescription: "ID of the cloud credential (e.g. a `chalk_aws_cloud_credentials`/`chalk_gcp_cloud_credentials`/`chalk_azure_cloud_credentials` resource) used to access the storage. Changing this forces a new resource.",
+			Required:            true,
+			PlanModifiers:       []planmodifier.String{stringplanmodifier.RequiresReplace()},
 		}
 	} else {
 		markdown = "Registers a reference to an existing (unmanaged) cloud storage bucket plus the cloud credential used to reach it. Chalk does not provision the bucket.\n\n" +
@@ -89,6 +95,13 @@ func cloudStorageSchema(managed bool) schema.Schema {
 			PlanModifiers: []planmodifier.String{
 				stringplanmodifier.RequiresReplace(),
 			},
+		}
+		credAttr = schema.StringAttribute{
+			MarkdownDescription: "ID of the cloud credential (e.g. a `chalk_aws_cloud_credentials`/`chalk_gcp_cloud_credentials`/`chalk_azure_cloud_credentials` resource) used to access the bucket. " +
+				"Optional for unmanaged storage: omit it when the bucket is reached via workload identity / instance IAM rather than an explicit Chalk credential (an imported bucket with no credential reads back null). " +
+				"Changing this forces a new resource.",
+			Optional:      true,
+			PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 		}
 	}
 
@@ -113,12 +126,8 @@ func cloudStorageSchema(managed bool) schema.Schema {
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
-			"uri": uriAttr,
-			"cloud_credential_id": schema.StringAttribute{
-				MarkdownDescription: "ID of the cloud credential (e.g. a `chalk_aws_cloud_credentials`/`chalk_gcp_cloud_credentials`/`chalk_azure_cloud_credentials` resource) used to access the bucket. Changing this forces a new resource.",
-				Required:            true,
-				PlanModifiers:       []planmodifier.String{stringplanmodifier.RequiresReplace()},
-			},
+			"uri":                 uriAttr,
+			"cloud_credential_id": credAttr,
 		},
 	}
 }


### PR DESCRIPTION
An unmanaged cloud storage that Chalk reaches via **workload identity / instance IAM** (rather than an explicit Chalk cloud credential) has no `cloud_credential_id`, so the server reads it back as `null`.

Today `cloud_credential_id` is `Required` (and replace-only) on `chalk_unmanaged_cloud_storage`, which makes such a bucket **impossible to import to a clean plan**:

- `terraform import` records `cloud_credential_id = null` (server has none).
- But any config for the resource must set `cloud_credential_id` (it is Required), so every plan shows a diff — or you get `Missing Configuration for Required Attribute` if you leave it unset.

There is no value you can write in config that matches the imported `null` state, so the resource is stuck in a perpetual replace/error loop.

## Fix

Make `cloud_credential_id` **Optional** in the *unmanaged* schema (it stays **Required** for `chalk_managed_cloud_storage`). This mirrors how `uri` is already parameterized by `managed` in `cloudStorageSchema(managed bool)` — one attribute, two shapes depending on whether Chalk owns the bucket.

An IAM-accessed unmanaged bucket can now be imported and planned with **zero diff** by simply omitting `cloud_credential_id`; buckets that do use a Chalk credential keep setting it exactly as before.

## Changes

- `internal/provider/cloud_storage_common.go` — `cloud_credential_id` built as `credAttr`: `Required` in the managed branch, `Optional` in the unmanaged branch (both retain `RequiresReplace`).
- `docs/resources/unmanaged_cloud_storage.md` — regenerated section moving `cloud_credential_id` to Optional with the new description.

## Testing

- `go build ./...` — clean.
- `gofmt` — clean.
- No existing test asserts `cloud_credential_id` is Required; the `cloud_storage_resource_test.go` cases set it explicitly and still pass (setting an Optional attribute is valid).

> Docs were updated by hand to match the schema change (my env cannot run `terraform`, which `make docs` invokes). Please run `make docs` to confirm exact tfplugindocs formatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)