### PR TITLE
Expose customer aggregator exporters on chalk_telemetry (SUP-49)

### DIFF
--- a/docs/resources/telemetry.md
+++ b/docs/resources/telemetry.md
@@ -26,7 +26,7 @@ Chalk telemetry resource
 
 - `aggregator_spec` (Attributes) Aggregator specification (see [below for nested schema](#nestedatt--aggregator_spec))
 - `clickhouse_deployment_spec` (Attributes) Clickhouse deployment specification (see [below for nested schema](#nestedatt--clickhouse_deployment_spec))
-- `customer_vector_aggregator` (Attributes) Forwards this deployment's telemetry to systems you own. Each destination is configured only when its block is present. Requires the Vector telemetry runtime; deployments on the OTel runtime store this configuration without deploying an exporter. (see [below for nested schema](#nestedatt--customer_vector_aggregator))
+- `customer_vector_aggregator` (Attributes) Forwards this deployment's telemetry to systems you own. Each destination is configured only when its block is present. Exporters configured outside Terraform are ignored until declared here. Requires the Vector telemetry runtime; deployments on the OTel runtime store this configuration without deploying an exporter. (see [below for nested schema](#nestedatt--customer_vector_aggregator))
 - `id` (String) Telemetry deployment identifier
 - `namespace` (String) Kubernetes namespace for the telemetry deployment
 - `otel_collector_spec` (Attributes) Otel collector specification (see [below for nested schema](#nestedatt--otel_collector_spec))

--- a/docs/resources/telemetry.md
+++ b/docs/resources/telemetry.md
@@ -105,7 +105,7 @@ Optional:
 
 Optional:
 
-- `datadog` (Attributes) Export telemetry to your own Datadog account. Logs, traces, and metrics all export by default; disable one with `enabled = false`. (see [below for nested schema](#nestedatt--exporters--datadog))
+- `datadog` (Attributes) Export telemetry to your own Datadog account. With no signal blocks, all of logs, traces, and metrics export; declaring any signal block exports only the declared signals. (see [below for nested schema](#nestedatt--exporters--datadog))
 - `otlp` (Attributes) Export metrics to an OTLP/HTTP endpoint you own. (see [below for nested schema](#nestedatt--exporters--otlp))
 
 <a id="nestedatt--exporters--datadog"></a>
@@ -118,16 +118,16 @@ Required:
 Optional:
 
 - `api_host` (String) Datadog site to export to, for example `datadoghq.eu`. Defaults to `datadoghq.com`.
-- `logs` (Attributes) Controls logs export, which is on by default. (see [below for nested schema](#nestedatt--exporters--datadog--logs))
-- `metrics` (Attributes) Controls metrics export, which is on by default. (see [below for nested schema](#nestedatt--exporters--datadog--metrics))
-- `traces` (Attributes) Controls traces export, which is on by default. (see [below for nested schema](#nestedatt--exporters--datadog--traces))
+- `logs` (Attributes) Export logs to your Datadog account. (see [below for nested schema](#nestedatt--exporters--datadog--logs))
+- `metrics` (Attributes) Export metrics to your Datadog account. (see [below for nested schema](#nestedatt--exporters--datadog--metrics))
+- `traces` (Attributes) Export traces to your Datadog account. (see [below for nested schema](#nestedatt--exporters--datadog--traces))
 
 <a id="nestedatt--exporters--datadog--logs"></a>
 ### Nested Schema for `exporters.datadog.logs`
 
 Optional:
 
-- `enabled` (Boolean) Whether to export logs. Defaults to `true`.
+- `enabled` (Boolean) Whether to export logs. Defaults to `true` when this block is declared.
 
 
 <a id="nestedatt--exporters--datadog--metrics"></a>
@@ -135,7 +135,7 @@ Optional:
 
 Optional:
 
-- `enabled` (Boolean) Whether to export metrics. Defaults to `true`.
+- `enabled` (Boolean) Whether to export metrics. Defaults to `true` when this block is declared.
 
 
 <a id="nestedatt--exporters--datadog--traces"></a>
@@ -143,7 +143,7 @@ Optional:
 
 Optional:
 
-- `enabled` (Boolean) Whether to export traces. Defaults to `true`.
+- `enabled` (Boolean) Whether to export traces. Defaults to `true` when this block is declared.
 
 
 

--- a/docs/resources/telemetry.md
+++ b/docs/resources/telemetry.md
@@ -105,7 +105,7 @@ Optional:
 
 Optional:
 
-- `datadog` (Attributes) Export telemetry to your own Datadog account. With no signal blocks, all of logs, traces, and metrics export; declaring any signal block exports only the declared signals. (see [below for nested schema](#nestedatt--exporters--datadog))
+- `datadog` (Attributes) Export telemetry to your own Datadog account. Logs, traces, and metrics all export by default; disable one with `enabled = false`. (see [below for nested schema](#nestedatt--exporters--datadog))
 - `otlp` (Attributes) Export metrics to an OTLP/HTTP endpoint you own. (see [below for nested schema](#nestedatt--exporters--otlp))
 
 <a id="nestedatt--exporters--datadog"></a>
@@ -127,7 +127,7 @@ Optional:
 
 Optional:
 
-- `enabled` (Boolean) Whether to export logs. Defaults to `true` when this block is declared.
+- `enabled` (Boolean) Whether to export logs. Defaults to `true`.
 
 
 <a id="nestedatt--exporters--datadog--metrics"></a>
@@ -135,7 +135,7 @@ Optional:
 
 Optional:
 
-- `enabled` (Boolean) Whether to export metrics. Defaults to `true` when this block is declared.
+- `enabled` (Boolean) Whether to export metrics. Defaults to `true`.
 
 
 <a id="nestedatt--exporters--datadog--traces"></a>
@@ -143,7 +143,7 @@ Optional:
 
 Optional:
 
-- `enabled` (Boolean) Whether to export traces. Defaults to `true` when this block is declared.
+- `enabled` (Boolean) Whether to export traces. Defaults to `true`.
 
 
 

--- a/docs/resources/telemetry.md
+++ b/docs/resources/telemetry.md
@@ -26,7 +26,7 @@ Chalk telemetry resource
 
 - `aggregator_spec` (Attributes) Aggregator specification (see [below for nested schema](#nestedatt--aggregator_spec))
 - `clickhouse_deployment_spec` (Attributes) Clickhouse deployment specification (see [below for nested schema](#nestedatt--clickhouse_deployment_spec))
-- `customer_vector_aggregator` (Attributes) Forwards this deployment's telemetry to systems you own. Each destination is configured only when its block is present. (see [below for nested schema](#nestedatt--customer_vector_aggregator))
+- `customer_vector_aggregator` (Attributes) Forwards this deployment's telemetry to systems you own. Each destination is configured only when its block is present. Requires the Vector telemetry runtime; deployments on the OTel runtime store this configuration without deploying an exporter. (see [below for nested schema](#nestedatt--customer_vector_aggregator))
 - `id` (String) Telemetry deployment identifier
 - `namespace` (String) Kubernetes namespace for the telemetry deployment
 - `otel_collector_spec` (Attributes) Otel collector specification (see [below for nested schema](#nestedatt--otel_collector_spec))

--- a/docs/resources/telemetry.md
+++ b/docs/resources/telemetry.md
@@ -26,7 +26,7 @@ Chalk telemetry resource
 
 - `aggregator_spec` (Attributes) Aggregator specification (see [below for nested schema](#nestedatt--aggregator_spec))
 - `clickhouse_deployment_spec` (Attributes) Clickhouse deployment specification (see [below for nested schema](#nestedatt--clickhouse_deployment_spec))
-- `customer_vector_aggregator` (Attributes) Forwards this deployment's telemetry to systems you own. Each destination is configured only when its block is present. Exporters configured outside Terraform are ignored until declared here. Requires the Vector telemetry runtime; deployments on the OTel runtime store this configuration without deploying an exporter. (see [below for nested schema](#nestedatt--customer_vector_aggregator))
+- `exporters` (Attributes) Forwards this deployment's telemetry to systems you own. Each destination is configured only when its block is present. Exporters configured outside Terraform are ignored until declared here. Requires the Vector telemetry runtime; deployments on the OTel runtime store this configuration without deploying an exporter. (see [below for nested schema](#nestedatt--exporters))
 - `id` (String) Telemetry deployment identifier
 - `namespace` (String) Kubernetes namespace for the telemetry deployment
 - `otel_collector_spec` (Attributes) Otel collector specification (see [below for nested schema](#nestedatt--otel_collector_spec))
@@ -100,16 +100,16 @@ Optional:
 
 
 
-<a id="nestedatt--customer_vector_aggregator"></a>
-### Nested Schema for `customer_vector_aggregator`
+<a id="nestedatt--exporters"></a>
+### Nested Schema for `exporters`
 
 Optional:
 
-- `datadog_export` (Attributes) Export telemetry to your own Datadog account. Nothing is exported until at least one of `logs`, `traces`, or `metrics` is present. (see [below for nested schema](#nestedatt--customer_vector_aggregator--datadog_export))
-- `otlp_metrics_export` (Attributes) Export metrics to an OTLP/HTTP endpoint you own. (see [below for nested schema](#nestedatt--customer_vector_aggregator--otlp_metrics_export))
+- `datadog` (Attributes) Export telemetry to your own Datadog account. Nothing is exported until at least one of `logs`, `traces`, or `metrics` is present. (see [below for nested schema](#nestedatt--exporters--datadog))
+- `otlp` (Attributes) Export metrics to an OTLP/HTTP endpoint you own. (see [below for nested schema](#nestedatt--exporters--otlp))
 
-<a id="nestedatt--customer_vector_aggregator--datadog_export"></a>
-### Nested Schema for `customer_vector_aggregator.datadog_export`
+<a id="nestedatt--exporters--datadog"></a>
+### Nested Schema for `exporters.datadog`
 
 Required:
 
@@ -118,28 +118,28 @@ Required:
 Optional:
 
 - `api_host` (String) Datadog site to export to, for example `datadoghq.eu`. Defaults to `datadoghq.com`.
-- `logs` (Attributes) Export logs to your Datadog account. Omitting this block leaves logs unexported. (see [below for nested schema](#nestedatt--customer_vector_aggregator--datadog_export--logs))
-- `metrics` (Attributes) Export metrics to your Datadog account. Omitting this block leaves metrics unexported. (see [below for nested schema](#nestedatt--customer_vector_aggregator--datadog_export--metrics))
-- `traces` (Attributes) Export traces to your Datadog account. Omitting this block leaves traces unexported. (see [below for nested schema](#nestedatt--customer_vector_aggregator--datadog_export--traces))
+- `logs` (Attributes) Export logs to your Datadog account. Omitting this block leaves logs unexported. (see [below for nested schema](#nestedatt--exporters--datadog--logs))
+- `metrics` (Attributes) Export metrics to your Datadog account. Omitting this block leaves metrics unexported. (see [below for nested schema](#nestedatt--exporters--datadog--metrics))
+- `traces` (Attributes) Export traces to your Datadog account. Omitting this block leaves traces unexported. (see [below for nested schema](#nestedatt--exporters--datadog--traces))
 
-<a id="nestedatt--customer_vector_aggregator--datadog_export--logs"></a>
-### Nested Schema for `customer_vector_aggregator.datadog_export.logs`
+<a id="nestedatt--exporters--datadog--logs"></a>
+### Nested Schema for `exporters.datadog.logs`
 
 Optional:
 
 - `enabled` (Boolean) Whether to export logs. Defaults to `true` when this block is present.
 
 
-<a id="nestedatt--customer_vector_aggregator--datadog_export--metrics"></a>
-### Nested Schema for `customer_vector_aggregator.datadog_export.metrics`
+<a id="nestedatt--exporters--datadog--metrics"></a>
+### Nested Schema for `exporters.datadog.metrics`
 
 Optional:
 
 - `enabled` (Boolean) Whether to export metrics. Defaults to `true` when this block is present.
 
 
-<a id="nestedatt--customer_vector_aggregator--datadog_export--traces"></a>
-### Nested Schema for `customer_vector_aggregator.datadog_export.traces`
+<a id="nestedatt--exporters--datadog--traces"></a>
+### Nested Schema for `exporters.datadog.traces`
 
 Optional:
 
@@ -147,8 +147,8 @@ Optional:
 
 
 
-<a id="nestedatt--customer_vector_aggregator--otlp_metrics_export"></a>
-### Nested Schema for `customer_vector_aggregator.otlp_metrics_export`
+<a id="nestedatt--exporters--otlp"></a>
+### Nested Schema for `exporters.otlp`
 
 Required:
 

--- a/docs/resources/telemetry.md
+++ b/docs/resources/telemetry.md
@@ -26,6 +26,7 @@ Chalk telemetry resource
 
 - `aggregator_spec` (Attributes) Aggregator specification (see [below for nested schema](#nestedatt--aggregator_spec))
 - `clickhouse_deployment_spec` (Attributes) Clickhouse deployment specification (see [below for nested schema](#nestedatt--clickhouse_deployment_spec))
+- `customer_vector_aggregator` (Attributes) Forwards this deployment's telemetry to systems you own. Each destination is configured only when its block is present. (see [below for nested schema](#nestedatt--customer_vector_aggregator))
 - `id` (String) Telemetry deployment identifier
 - `namespace` (String) Kubernetes namespace for the telemetry deployment
 - `otel_collector_spec` (Attributes) Otel collector specification (see [below for nested schema](#nestedatt--otel_collector_spec))
@@ -96,6 +97,67 @@ Optional:
 
 - `storage` (String) Storage resource specification
 - `storage_class_name` (String) Storage class name
+
+
+
+<a id="nestedatt--customer_vector_aggregator"></a>
+### Nested Schema for `customer_vector_aggregator`
+
+Optional:
+
+- `datadog_export` (Attributes) Export telemetry to your own Datadog account. Nothing is exported until at least one of `logs`, `traces`, or `metrics` is present. (see [below for nested schema](#nestedatt--customer_vector_aggregator--datadog_export))
+- `otlp_metrics_export` (Attributes) Export metrics to an OTLP/HTTP endpoint you own. (see [below for nested schema](#nestedatt--customer_vector_aggregator--otlp_metrics_export))
+
+<a id="nestedatt--customer_vector_aggregator--datadog_export"></a>
+### Nested Schema for `customer_vector_aggregator.datadog_export`
+
+Required:
+
+- `api_key_secret_reference` (String) Reference to the cloud secret holding your Datadog API key: an AWS Secrets Manager ARN, a GCP `projects/<project>/secrets/<name>` resource name, or an Azure Key Vault secret URL. The secret must live in the telemetry cluster's own account, and its latest version is read at deploy time.
+
+Optional:
+
+- `api_host` (String) Datadog site to export to, for example `datadoghq.eu`. Defaults to `datadoghq.com`.
+- `logs` (Attributes) Export logs to your Datadog account. Omitting this block leaves logs unexported. (see [below for nested schema](#nestedatt--customer_vector_aggregator--datadog_export--logs))
+- `metrics` (Attributes) Export metrics to your Datadog account. Omitting this block leaves metrics unexported. (see [below for nested schema](#nestedatt--customer_vector_aggregator--datadog_export--metrics))
+- `traces` (Attributes) Export traces to your Datadog account. Omitting this block leaves traces unexported. (see [below for nested schema](#nestedatt--customer_vector_aggregator--datadog_export--traces))
+
+<a id="nestedatt--customer_vector_aggregator--datadog_export--logs"></a>
+### Nested Schema for `customer_vector_aggregator.datadog_export.logs`
+
+Optional:
+
+- `enabled` (Boolean) Whether to export logs. Defaults to `true` when this block is present.
+
+
+<a id="nestedatt--customer_vector_aggregator--datadog_export--metrics"></a>
+### Nested Schema for `customer_vector_aggregator.datadog_export.metrics`
+
+Optional:
+
+- `enabled` (Boolean) Whether to export metrics. Defaults to `true` when this block is present.
+
+
+<a id="nestedatt--customer_vector_aggregator--datadog_export--traces"></a>
+### Nested Schema for `customer_vector_aggregator.datadog_export.traces`
+
+Optional:
+
+- `enabled` (Boolean) Whether to export traces. Defaults to `true` when this block is present.
+
+
+
+<a id="nestedatt--customer_vector_aggregator--otlp_metrics_export"></a>
+### Nested Schema for `customer_vector_aggregator.otlp_metrics_export`
+
+Required:
+
+- `url` (String) Full OTLP/HTTP metrics URL, including the `/v1/metrics` path.
+
+Optional:
+
+- `authorization_header_secret_reference` (String) Reference to the cloud secret holding the complete `Authorization` header value, for example `Bearer <token>`. Accepts an AWS Secrets Manager ARN, a GCP `projects/<project>/secrets/<name>` resource name, or an Azure Key Vault secret URL.
+- `enabled` (Boolean) Whether to export metrics. Defaults to `true` when this block is present.
 
 
 

--- a/docs/resources/telemetry.md
+++ b/docs/resources/telemetry.md
@@ -105,7 +105,7 @@ Optional:
 
 Optional:
 
-- `datadog` (Attributes) Export telemetry to your own Datadog account. Nothing is exported until at least one of `logs`, `traces`, or `metrics` is present. (see [below for nested schema](#nestedatt--exporters--datadog))
+- `datadog` (Attributes) Export telemetry to your own Datadog account. Logs, traces, and metrics all export by default; disable one with `enabled = false`. (see [below for nested schema](#nestedatt--exporters--datadog))
 - `otlp` (Attributes) Export metrics to an OTLP/HTTP endpoint you own. (see [below for nested schema](#nestedatt--exporters--otlp))
 
 <a id="nestedatt--exporters--datadog"></a>
@@ -118,16 +118,16 @@ Required:
 Optional:
 
 - `api_host` (String) Datadog site to export to, for example `datadoghq.eu`. Defaults to `datadoghq.com`.
-- `logs` (Attributes) Export logs to your Datadog account. Omitting this block leaves logs unexported. (see [below for nested schema](#nestedatt--exporters--datadog--logs))
-- `metrics` (Attributes) Export metrics to your Datadog account. Omitting this block leaves metrics unexported. (see [below for nested schema](#nestedatt--exporters--datadog--metrics))
-- `traces` (Attributes) Export traces to your Datadog account. Omitting this block leaves traces unexported. (see [below for nested schema](#nestedatt--exporters--datadog--traces))
+- `logs` (Attributes) Controls logs export, which is on by default. (see [below for nested schema](#nestedatt--exporters--datadog--logs))
+- `metrics` (Attributes) Controls metrics export, which is on by default. (see [below for nested schema](#nestedatt--exporters--datadog--metrics))
+- `traces` (Attributes) Controls traces export, which is on by default. (see [below for nested schema](#nestedatt--exporters--datadog--traces))
 
 <a id="nestedatt--exporters--datadog--logs"></a>
 ### Nested Schema for `exporters.datadog.logs`
 
 Optional:
 
-- `enabled` (Boolean) Whether to export logs. Defaults to `true` when this block is present.
+- `enabled` (Boolean) Whether to export logs. Defaults to `true`.
 
 
 <a id="nestedatt--exporters--datadog--metrics"></a>
@@ -135,7 +135,7 @@ Optional:
 
 Optional:
 
-- `enabled` (Boolean) Whether to export metrics. Defaults to `true` when this block is present.
+- `enabled` (Boolean) Whether to export metrics. Defaults to `true`.
 
 
 <a id="nestedatt--exporters--datadog--traces"></a>
@@ -143,7 +143,7 @@ Optional:
 
 Optional:
 
-- `enabled` (Boolean) Whether to export traces. Defaults to `true` when this block is present.
+- `enabled` (Boolean) Whether to export traces. Defaults to `true`.
 
 
 

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.26.1
 
 require (
 	connectrpc.com/connect v1.19.1
-	github.com/chalk-ai/chalk-go v1.2.278
-	github.com/chalk-ai/chalk-go/gen v1.2.278
+	github.com/chalk-ai/chalk-go v1.2.289
+	github.com/chalk-ai/chalk-go/gen v1.2.289
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/terraform-plugin-docs v0.24.0
 	github.com/hashicorp/terraform-plugin-framework v1.14.1

--- a/go.sum
+++ b/go.sum
@@ -35,10 +35,10 @@ github.com/bufbuild/protocompile v0.14.1 h1:iA73zAf/fyljNjQKwYzUHD6AD4R8KMasmwa/
 github.com/bufbuild/protocompile v0.14.1/go.mod h1:ppVdAIhbr2H8asPk6k4pY7t9zB1OU5DoEw9xY/FUi1c=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/chalk-ai/chalk-go v1.2.278 h1:sT06+lfus0A2MVxhqUB3eHMzIhyWD9Y6z12NRD1OOBo=
-github.com/chalk-ai/chalk-go v1.2.278/go.mod h1:Nw+JJY46b5cs7kYwUPHd0+8tehurvFddyE+1BO/DKhI=
-github.com/chalk-ai/chalk-go/gen v1.2.278 h1:Ovt1EPBRpeOuO47POnXKXqv7RMq7a6X0NtzO8qiQPlc=
-github.com/chalk-ai/chalk-go/gen v1.2.278/go.mod h1:Cd47/VOgt1NJD9LOeSGxiypc8hLOGZ4y8NTO13uVnzc=
+github.com/chalk-ai/chalk-go v1.2.289 h1:OqiVM0ExeSXWhwnYrpO9lP1ExaSBNQmL+4t4V3vovnc=
+github.com/chalk-ai/chalk-go v1.2.289/go.mod h1:9FSSpDFxEll5NseQ9TwtGIPPrI9rnqpUzg381Q7Oyfs=
+github.com/chalk-ai/chalk-go/gen v1.2.289 h1:ronaW60hPnlyiIFYvG/Bfs/UItxfrtHTR/HRGfokTZE=
+github.com/chalk-ai/chalk-go/gen v1.2.289/go.mod h1:Cd47/VOgt1NJD9LOeSGxiypc8hLOGZ4y8NTO13uVnzc=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
 github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=

--- a/internal/provider/cluster_config_common.go
+++ b/internal/provider/cluster_config_common.go
@@ -15,6 +15,8 @@ import (
 // This file holds the cluster-level configuration that both chalk_managed_cluster
 // and chalk_kubernetes_cluster expose on the CloudComponentCluster spec.
 
+//lint:file-ignore SA1019 host_pools is a released attribute; moving it to HostPoolService is a separate, breaking change.
+
 // Maintenance window modes, exposed as short (prefix-stripped) strings.
 const (
 	maintenanceModeUnspecified  = "UNSPECIFIED"

--- a/internal/provider/helpers.go
+++ b/internal/provider/helpers.go
@@ -54,9 +54,7 @@ func stringPointerValue(p *string) types.String {
 	return types.StringValue(*p)
 }
 
-// boolPointerValue converts an optional (nullable) proto bool to a types.Bool
-// using presence: a nil pointer becomes null. Pair it with
-// types.Bool.ValueBoolPointer() so "unset" survives a round trip.
+// boolPointerValue maps a nil proto bool to null so "unset" survives a round trip.
 func boolPointerValue(p *bool) types.Bool {
 	if p == nil {
 		return types.BoolNull()

--- a/internal/provider/helpers.go
+++ b/internal/provider/helpers.go
@@ -54,6 +54,16 @@ func stringPointerValue(p *string) types.String {
 	return types.StringValue(*p)
 }
 
+// boolPointerValue converts an optional (nullable) proto bool to a types.Bool
+// using presence: a nil pointer becomes null. Pair it with
+// types.Bool.ValueBoolPointer() so "unset" survives a round trip.
+func boolPointerValue(p *bool) types.Bool {
+	if p == nil {
+		return types.BoolNull()
+	}
+	return types.BoolValue(*p)
+}
+
 // kubeResourceConfigObject converts a KubeResourceConfig proto to a types.Object.
 func kubeResourceConfigObject(rc *serverv1.KubeResourceConfig) types.Object {
 	if rc == nil {

--- a/internal/provider/kubernetes_cluster_resource_test.go
+++ b/internal/provider/kubernetes_cluster_resource_test.go
@@ -1,5 +1,7 @@
 package provider
 
+//lint:file-ignore SA1019 Covers the deprecated host_pools attribute, which is still released.
+
 import (
 	"regexp"
 	"testing"

--- a/internal/provider/telemetry_customer_aggregator.go
+++ b/internal/provider/telemetry_customer_aggregator.go
@@ -35,8 +35,7 @@ type customerOtlpMetricsExportModel struct {
 
 const secretReferenceFormats = "an AWS Secrets Manager ARN, a GCP `projects/<project>/secrets/<name>` resource name, or an Azure Key Vault secret URL"
 
-// datadogSignalExportSchema describes one Datadog signal. Presence is what turns the
-// signal on, so `logs = {}` means "export logs" and omitting the block means "don't".
+// datadogSignalExportSchema describes one Datadog signal, which presence alone enables.
 func datadogSignalExportSchema(signal string) schema.SingleNestedAttribute {
 	return schema.SingleNestedAttribute{
 		MarkdownDescription: fmt.Sprintf("Export %s to your Datadog account. Omitting this block leaves %s unexported.", signal, signal),
@@ -146,9 +145,7 @@ func (m *customerOtlpMetricsExportModel) toProto() *serverv1.CustomerVectorAggre
 }
 
 func customerVectorAggregatorFromProto(p *serverv1.CustomerVectorAggregatorConfig) *customerVectorAggregatorModel {
-	// The same proto message also carries replicas, statsd_export and remap VRL, which
-	// this resource does not model. A deployment holding only those must read back as
-	// unset, or a configuration that never declared the block would drift every plan.
+	// Nil unless an exporter is set, so unmodelled siblings like replicas don't drift.
 	if p.GetDatadogExport() == nil && p.GetOtlpMetricsExport() == nil {
 		return nil
 	}
@@ -163,8 +160,7 @@ func customerDatadogExportFromProto(p *serverv1.CustomerVectorAggregatorDatadogE
 		return nil
 	}
 	return &customerDatadogExportModel{
-		// Empty when the deployment stores an inline API key instead, which this
-		// resource never writes; the plan then shows the configured reference.
+		// Empty when the deployment stores an inline API key, which this resource never writes.
 		ApiKeySecretReference: optionalStringValue(p.GetApiKeySecretArn()),
 		ApiHost:               stringPointerValue(p.ApiHost),
 		Logs:                  customerDatadogSignalFromProto(p.GetLogs()),

--- a/internal/provider/telemetry_customer_aggregator.go
+++ b/internal/provider/telemetry_customer_aggregator.go
@@ -38,14 +38,14 @@ type customerOtlpMetricsExportModel struct {
 
 const secretReferenceFormats = "an AWS Secrets Manager ARN, a GCP `projects/<project>/secrets/<name>` resource name, or an Azure Key Vault secret URL"
 
-// datadogSignalExportSchema describes one Datadog signal, which presence alone enables.
+// datadogSignalExportSchema describes one Datadog signal.
 func datadogSignalExportSchema(signal string) schema.SingleNestedAttribute {
 	return schema.SingleNestedAttribute{
-		MarkdownDescription: fmt.Sprintf("Export %s to your Datadog account. Omitting this block leaves %s unexported.", signal, signal),
+		MarkdownDescription: fmt.Sprintf("Controls %s export, which is on by default.", signal),
 		Optional:            true,
 		Attributes: map[string]schema.Attribute{
 			"enabled": schema.BoolAttribute{
-				MarkdownDescription: fmt.Sprintf("Whether to export %s. Defaults to `true` when this block is present.", signal),
+				MarkdownDescription: fmt.Sprintf("Whether to export %s. Defaults to `true`.", signal),
 				Optional:            true,
 			},
 		},
@@ -58,7 +58,7 @@ func customerVectorAggregatorSchema() schema.SingleNestedAttribute {
 		Optional:            true,
 		Attributes: map[string]schema.Attribute{
 			"datadog": schema.SingleNestedAttribute{
-				MarkdownDescription: "Export telemetry to your own Datadog account. Nothing is exported until at least one of `logs`, `traces`, or `metrics` is present.",
+				MarkdownDescription: "Export telemetry to your own Datadog account. Logs, traces, and metrics all export by default; disable one with `enabled = false`.",
 				Optional:            true,
 				Validators: []validator.Object{
 					objectvalidator.AtLeastOneOf(

--- a/internal/provider/telemetry_customer_aggregator.go
+++ b/internal/provider/telemetry_customer_aggregator.go
@@ -45,7 +45,7 @@ func datadogSignalExportSchema(signal string) schema.SingleNestedAttribute {
 		Optional:            true,
 		Attributes: map[string]schema.Attribute{
 			"enabled": schema.BoolAttribute{
-				MarkdownDescription: fmt.Sprintf("Whether to export %s. Defaults to `true` when this block is declared.", signal),
+				MarkdownDescription: fmt.Sprintf("Whether to export %s. Defaults to `true`.", signal),
 				Optional:            true,
 			},
 		},
@@ -58,7 +58,7 @@ func customerVectorAggregatorSchema() schema.SingleNestedAttribute {
 		Optional:            true,
 		Attributes: map[string]schema.Attribute{
 			"datadog": schema.SingleNestedAttribute{
-				MarkdownDescription: "Export telemetry to your own Datadog account. With no signal blocks, all of logs, traces, and metrics export; declaring any signal block exports only the declared signals.",
+				MarkdownDescription: "Export telemetry to your own Datadog account. Logs, traces, and metrics all export by default; disable one with `enabled = false`.",
 				Optional:            true,
 				Validators: []validator.Object{
 					objectvalidator.AtLeastOneOf(

--- a/internal/provider/telemetry_customer_aggregator.go
+++ b/internal/provider/telemetry_customer_aggregator.go
@@ -4,10 +4,13 @@ import (
 	"fmt"
 
 	serverv1 "github.com/chalk-ai/chalk-go/gen/chalk/server/v1"
+	"github.com/hashicorp/terraform-plugin-framework-validators/objectvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"google.golang.org/protobuf/proto"
 )
 
 type customerVectorAggregatorModel struct {
@@ -51,12 +54,17 @@ func datadogSignalExportSchema(signal string) schema.SingleNestedAttribute {
 
 func customerVectorAggregatorSchema() schema.SingleNestedAttribute {
 	return schema.SingleNestedAttribute{
-		MarkdownDescription: "Forwards this deployment's telemetry to systems you own. Each destination is configured only when its block is present.",
+		MarkdownDescription: "Forwards this deployment's telemetry to systems you own. Each destination is configured only when its block is present. Requires the Vector telemetry runtime; deployments on the OTel runtime store this configuration without deploying an exporter.",
 		Optional:            true,
 		Attributes: map[string]schema.Attribute{
 			"datadog_export": schema.SingleNestedAttribute{
 				MarkdownDescription: "Export telemetry to your own Datadog account. Nothing is exported until at least one of `logs`, `traces`, or `metrics` is present.",
 				Optional:            true,
+				Validators: []validator.Object{
+					objectvalidator.AtLeastOneOf(
+						path.MatchRelative().AtParent().AtName("otlp_metrics_export"),
+					),
+				},
 				Attributes: map[string]schema.Attribute{
 					"api_key_secret_reference": schema.StringAttribute{
 						MarkdownDescription: "Reference to the cloud secret holding your Datadog API key: " + secretReferenceFormats + ". The secret must live in the telemetry cluster's own account, and its latest version is read at deploy time.",
@@ -142,6 +150,46 @@ func (m *customerOtlpMetricsExportModel) toProto() *serverv1.CustomerVectorAggre
 		Url:                          m.Url.ValueString(),
 		AuthorizationHeaderSecretArn: m.AuthorizationHeaderSecretReference.ValueStringPointer(),
 	}
+}
+
+// customerVectorAggregatorMaskPaths masks only fields this resource owns, so unmodelled
+// fields like remap_vrl and metrics_sink survive; whole-message paths are used only to clear.
+func customerVectorAggregatorMaskPaths(plan, state *customerVectorAggregatorModel) []string {
+	var paths []string
+	planProto, stateProto := plan.toProto(), state.toProto()
+	if dd := planProto.GetDatadogExport(); !proto.Equal(dd, stateProto.GetDatadogExport()) {
+		if dd == nil {
+			paths = append(paths, "customer_vector_aggregator.datadog_export")
+		} else {
+			paths = append(paths,
+				"customer_vector_aggregator.datadog_export.api_key_secret_arn",
+				"customer_vector_aggregator.datadog_export.api_host",
+			)
+			for _, signal := range []struct {
+				name string
+				set  *serverv1.CustomerVectorAggregatorDatadogSignalExportSpec
+			}{{"logs", dd.GetLogs()}, {"traces", dd.GetTraces()}, {"metrics", dd.GetMetrics()}} {
+				if signal.set == nil {
+					paths = append(paths, "customer_vector_aggregator.datadog_export."+signal.name)
+				} else {
+					// Masking enabled under an absent signal would create it; fmutils fills in parents.
+					paths = append(paths, "customer_vector_aggregator.datadog_export."+signal.name+".enabled")
+				}
+			}
+		}
+	}
+	if otlp := planProto.GetOtlpMetricsExport(); !proto.Equal(otlp, stateProto.GetOtlpMetricsExport()) {
+		if otlp == nil {
+			paths = append(paths, "customer_vector_aggregator.otlp_metrics_export")
+		} else {
+			paths = append(paths,
+				"customer_vector_aggregator.otlp_metrics_export.enabled",
+				"customer_vector_aggregator.otlp_metrics_export.url",
+				"customer_vector_aggregator.otlp_metrics_export.authorization_header_secret_arn",
+			)
+		}
+	}
+	return paths
 }
 
 func customerVectorAggregatorFromProto(p *serverv1.CustomerVectorAggregatorConfig) *customerVectorAggregatorModel {

--- a/internal/provider/telemetry_customer_aggregator.go
+++ b/internal/provider/telemetry_customer_aggregator.go
@@ -54,7 +54,7 @@ func datadogSignalExportSchema(signal string) schema.SingleNestedAttribute {
 
 func customerVectorAggregatorSchema() schema.SingleNestedAttribute {
 	return schema.SingleNestedAttribute{
-		MarkdownDescription: "Forwards this deployment's telemetry to systems you own. Each destination is configured only when its block is present. Requires the Vector telemetry runtime; deployments on the OTel runtime store this configuration without deploying an exporter.",
+		MarkdownDescription: "Forwards this deployment's telemetry to systems you own. Each destination is configured only when its block is present. Exporters configured outside Terraform are ignored until declared here. Requires the Vector telemetry runtime; deployments on the OTel runtime store this configuration without deploying an exporter.",
 		Optional:            true,
 		Attributes: map[string]schema.Attribute{
 			"datadog_export": schema.SingleNestedAttribute{
@@ -192,15 +192,23 @@ func customerVectorAggregatorMaskPaths(plan, state *customerVectorAggregatorMode
 	return paths
 }
 
-func customerVectorAggregatorFromProto(p *serverv1.CustomerVectorAggregatorConfig) *customerVectorAggregatorModel {
-	// Nil unless an exporter is set, so unmodelled siblings like replicas don't drift.
-	if p.GetDatadogExport() == nil && p.GetOtlpMetricsExport() == nil {
+// Each exporter is adopted from the server only when prior state owns it, so exporters
+// configured through other clients are never pulled into state and planned away.
+func customerVectorAggregatorFromProto(p *serverv1.CustomerVectorAggregatorConfig, prior *customerVectorAggregatorModel) *customerVectorAggregatorModel {
+	if prior == nil {
 		return nil
 	}
-	return &customerVectorAggregatorModel{
-		DatadogExport:     customerDatadogExportFromProto(p.GetDatadogExport()),
-		OtlpMetricsExport: customerOtlpMetricsExportFromProto(p.GetOtlpMetricsExport()),
+	m := &customerVectorAggregatorModel{}
+	if prior.DatadogExport != nil {
+		m.DatadogExport = customerDatadogExportFromProto(p.GetDatadogExport())
 	}
+	if prior.OtlpMetricsExport != nil {
+		m.OtlpMetricsExport = customerOtlpMetricsExportFromProto(p.GetOtlpMetricsExport())
+	}
+	if m.DatadogExport == nil && m.OtlpMetricsExport == nil {
+		return nil
+	}
+	return m
 }
 
 func customerDatadogExportFromProto(p *serverv1.CustomerVectorAggregatorDatadogExportConfig) *customerDatadogExportModel {

--- a/internal/provider/telemetry_customer_aggregator.go
+++ b/internal/provider/telemetry_customer_aggregator.go
@@ -41,11 +41,11 @@ const secretReferenceFormats = "an AWS Secrets Manager ARN, a GCP `projects/<pro
 // datadogSignalExportSchema describes one Datadog signal.
 func datadogSignalExportSchema(signal string) schema.SingleNestedAttribute {
 	return schema.SingleNestedAttribute{
-		MarkdownDescription: fmt.Sprintf("Controls %s export, which is on by default.", signal),
+		MarkdownDescription: fmt.Sprintf("Export %s to your Datadog account.", signal),
 		Optional:            true,
 		Attributes: map[string]schema.Attribute{
 			"enabled": schema.BoolAttribute{
-				MarkdownDescription: fmt.Sprintf("Whether to export %s. Defaults to `true`.", signal),
+				MarkdownDescription: fmt.Sprintf("Whether to export %s. Defaults to `true` when this block is declared.", signal),
 				Optional:            true,
 			},
 		},
@@ -58,7 +58,7 @@ func customerVectorAggregatorSchema() schema.SingleNestedAttribute {
 		Optional:            true,
 		Attributes: map[string]schema.Attribute{
 			"datadog": schema.SingleNestedAttribute{
-				MarkdownDescription: "Export telemetry to your own Datadog account. Logs, traces, and metrics all export by default; disable one with `enabled = false`.",
+				MarkdownDescription: "Export telemetry to your own Datadog account. With no signal blocks, all of logs, traces, and metrics export; declaring any signal block exports only the declared signals.",
 				Optional:            true,
 				Validators: []validator.Object{
 					objectvalidator.AtLeastOneOf(

--- a/internal/provider/telemetry_customer_aggregator.go
+++ b/internal/provider/telemetry_customer_aggregator.go
@@ -1,0 +1,192 @@
+package provider
+
+import (
+	"fmt"
+
+	serverv1 "github.com/chalk-ai/chalk-go/gen/chalk/server/v1"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type customerVectorAggregatorModel struct {
+	DatadogExport     *customerDatadogExportModel     `tfsdk:"datadog_export"`
+	OtlpMetricsExport *customerOtlpMetricsExportModel `tfsdk:"otlp_metrics_export"`
+}
+
+type customerDatadogExportModel struct {
+	ApiKeySecretReference types.String                `tfsdk:"api_key_secret_reference"`
+	ApiHost               types.String                `tfsdk:"api_host"`
+	Logs                  *customerDatadogSignalModel `tfsdk:"logs"`
+	Traces                *customerDatadogSignalModel `tfsdk:"traces"`
+	Metrics               *customerDatadogSignalModel `tfsdk:"metrics"`
+}
+
+type customerDatadogSignalModel struct {
+	Enabled types.Bool `tfsdk:"enabled"`
+}
+
+type customerOtlpMetricsExportModel struct {
+	Enabled                            types.Bool   `tfsdk:"enabled"`
+	Url                                types.String `tfsdk:"url"`
+	AuthorizationHeaderSecretReference types.String `tfsdk:"authorization_header_secret_reference"`
+}
+
+const secretReferenceFormats = "an AWS Secrets Manager ARN, a GCP `projects/<project>/secrets/<name>` resource name, or an Azure Key Vault secret URL"
+
+// datadogSignalExportSchema describes one Datadog signal. Presence is what turns the
+// signal on, so `logs = {}` means "export logs" and omitting the block means "don't".
+func datadogSignalExportSchema(signal string) schema.SingleNestedAttribute {
+	return schema.SingleNestedAttribute{
+		MarkdownDescription: fmt.Sprintf("Export %s to your Datadog account. Omitting this block leaves %s unexported.", signal, signal),
+		Optional:            true,
+		Attributes: map[string]schema.Attribute{
+			"enabled": schema.BoolAttribute{
+				MarkdownDescription: fmt.Sprintf("Whether to export %s. Defaults to `true` when this block is present.", signal),
+				Optional:            true,
+			},
+		},
+	}
+}
+
+func customerVectorAggregatorSchema() schema.SingleNestedAttribute {
+	return schema.SingleNestedAttribute{
+		MarkdownDescription: "Forwards this deployment's telemetry to systems you own. Each destination is configured only when its block is present.",
+		Optional:            true,
+		Attributes: map[string]schema.Attribute{
+			"datadog_export": schema.SingleNestedAttribute{
+				MarkdownDescription: "Export telemetry to your own Datadog account. Nothing is exported until at least one of `logs`, `traces`, or `metrics` is present.",
+				Optional:            true,
+				Attributes: map[string]schema.Attribute{
+					"api_key_secret_reference": schema.StringAttribute{
+						MarkdownDescription: "Reference to the cloud secret holding your Datadog API key: " + secretReferenceFormats + ". The secret must live in the telemetry cluster's own account, and its latest version is read at deploy time.",
+						Required:            true,
+						Validators: []validator.String{
+							stringvalidator.LengthAtLeast(1),
+						},
+					},
+					"api_host": schema.StringAttribute{
+						MarkdownDescription: "Datadog site to export to, for example `datadoghq.eu`. Defaults to `datadoghq.com`.",
+						Optional:            true,
+					},
+					"logs":    datadogSignalExportSchema("logs"),
+					"traces":  datadogSignalExportSchema("traces"),
+					"metrics": datadogSignalExportSchema("metrics"),
+				},
+			},
+			"otlp_metrics_export": schema.SingleNestedAttribute{
+				MarkdownDescription: "Export metrics to an OTLP/HTTP endpoint you own.",
+				Optional:            true,
+				Attributes: map[string]schema.Attribute{
+					"url": schema.StringAttribute{
+						MarkdownDescription: "Full OTLP/HTTP metrics URL, including the `/v1/metrics` path.",
+						Required:            true,
+						Validators: []validator.String{
+							stringvalidator.LengthAtLeast(1),
+						},
+					},
+					"enabled": schema.BoolAttribute{
+						MarkdownDescription: "Whether to export metrics. Defaults to `true` when this block is present.",
+						Optional:            true,
+					},
+					"authorization_header_secret_reference": schema.StringAttribute{
+						MarkdownDescription: "Reference to the cloud secret holding the complete `Authorization` header value, for example `Bearer <token>`. Accepts " + secretReferenceFormats + ".",
+						Optional:            true,
+					},
+				},
+			},
+		},
+	}
+}
+
+func (m *customerVectorAggregatorModel) toProto() *serverv1.CustomerVectorAggregatorConfig {
+	if m == nil {
+		return nil
+	}
+	return &serverv1.CustomerVectorAggregatorConfig{
+		DatadogExport:     m.DatadogExport.toProto(),
+		OtlpMetricsExport: m.OtlpMetricsExport.toProto(),
+	}
+}
+
+func (m *customerDatadogExportModel) toProto() *serverv1.CustomerVectorAggregatorDatadogExportConfig {
+	if m == nil {
+		return nil
+	}
+	return &serverv1.CustomerVectorAggregatorDatadogExportConfig{
+		ApiKeySource: &serverv1.CustomerVectorAggregatorDatadogExportConfig_ApiKeySecretArn{
+			ApiKeySecretArn: m.ApiKeySecretReference.ValueString(),
+		},
+		ApiHost: m.ApiHost.ValueStringPointer(),
+		Logs:    m.Logs.toProto(),
+		Traces:  m.Traces.toProto(),
+		Metrics: m.Metrics.toProto(),
+	}
+}
+
+func (m *customerDatadogSignalModel) toProto() *serverv1.CustomerVectorAggregatorDatadogSignalExportSpec {
+	if m == nil {
+		return nil
+	}
+	return &serverv1.CustomerVectorAggregatorDatadogSignalExportSpec{
+		Enabled: m.Enabled.ValueBoolPointer(),
+	}
+}
+
+func (m *customerOtlpMetricsExportModel) toProto() *serverv1.CustomerVectorAggregatorOtlpMetricsExportConfig {
+	if m == nil {
+		return nil
+	}
+	return &serverv1.CustomerVectorAggregatorOtlpMetricsExportConfig{
+		Enabled:                      m.Enabled.ValueBoolPointer(),
+		Url:                          m.Url.ValueString(),
+		AuthorizationHeaderSecretArn: m.AuthorizationHeaderSecretReference.ValueStringPointer(),
+	}
+}
+
+func customerVectorAggregatorFromProto(p *serverv1.CustomerVectorAggregatorConfig) *customerVectorAggregatorModel {
+	// The same proto message also carries replicas, statsd_export and remap VRL, which
+	// this resource does not model. A deployment holding only those must read back as
+	// unset, or a configuration that never declared the block would drift every plan.
+	if p.GetDatadogExport() == nil && p.GetOtlpMetricsExport() == nil {
+		return nil
+	}
+	return &customerVectorAggregatorModel{
+		DatadogExport:     customerDatadogExportFromProto(p.GetDatadogExport()),
+		OtlpMetricsExport: customerOtlpMetricsExportFromProto(p.GetOtlpMetricsExport()),
+	}
+}
+
+func customerDatadogExportFromProto(p *serverv1.CustomerVectorAggregatorDatadogExportConfig) *customerDatadogExportModel {
+	if p == nil {
+		return nil
+	}
+	return &customerDatadogExportModel{
+		// Empty when the deployment stores an inline API key instead, which this
+		// resource never writes; the plan then shows the configured reference.
+		ApiKeySecretReference: optionalStringValue(p.GetApiKeySecretArn()),
+		ApiHost:               stringPointerValue(p.ApiHost),
+		Logs:                  customerDatadogSignalFromProto(p.GetLogs()),
+		Traces:                customerDatadogSignalFromProto(p.GetTraces()),
+		Metrics:               customerDatadogSignalFromProto(p.GetMetrics()),
+	}
+}
+
+func customerDatadogSignalFromProto(p *serverv1.CustomerVectorAggregatorDatadogSignalExportSpec) *customerDatadogSignalModel {
+	if p == nil {
+		return nil
+	}
+	return &customerDatadogSignalModel{Enabled: boolPointerValue(p.Enabled)}
+}
+
+func customerOtlpMetricsExportFromProto(p *serverv1.CustomerVectorAggregatorOtlpMetricsExportConfig) *customerOtlpMetricsExportModel {
+	if p == nil {
+		return nil
+	}
+	return &customerOtlpMetricsExportModel{
+		Enabled:                            boolPointerValue(p.Enabled),
+		Url:                                optionalStringValue(p.GetUrl()),
+		AuthorizationHeaderSecretReference: stringPointerValue(p.AuthorizationHeaderSecretArn),
+	}
+}

--- a/internal/provider/telemetry_customer_aggregator.go
+++ b/internal/provider/telemetry_customer_aggregator.go
@@ -14,8 +14,8 @@ import (
 )
 
 type customerVectorAggregatorModel struct {
-	DatadogExport     *customerDatadogExportModel     `tfsdk:"datadog_export"`
-	OtlpMetricsExport *customerOtlpMetricsExportModel `tfsdk:"otlp_metrics_export"`
+	Datadog *customerDatadogExportModel     `tfsdk:"datadog"`
+	Otlp    *customerOtlpMetricsExportModel `tfsdk:"otlp"`
 }
 
 type customerDatadogExportModel struct {
@@ -57,12 +57,12 @@ func customerVectorAggregatorSchema() schema.SingleNestedAttribute {
 		MarkdownDescription: "Forwards this deployment's telemetry to systems you own. Each destination is configured only when its block is present. Exporters configured outside Terraform are ignored until declared here. Requires the Vector telemetry runtime; deployments on the OTel runtime store this configuration without deploying an exporter.",
 		Optional:            true,
 		Attributes: map[string]schema.Attribute{
-			"datadog_export": schema.SingleNestedAttribute{
+			"datadog": schema.SingleNestedAttribute{
 				MarkdownDescription: "Export telemetry to your own Datadog account. Nothing is exported until at least one of `logs`, `traces`, or `metrics` is present.",
 				Optional:            true,
 				Validators: []validator.Object{
 					objectvalidator.AtLeastOneOf(
-						path.MatchRelative().AtParent().AtName("otlp_metrics_export"),
+						path.MatchRelative().AtParent().AtName("otlp"),
 					),
 				},
 				Attributes: map[string]schema.Attribute{
@@ -82,7 +82,7 @@ func customerVectorAggregatorSchema() schema.SingleNestedAttribute {
 					"metrics": datadogSignalExportSchema("metrics"),
 				},
 			},
-			"otlp_metrics_export": schema.SingleNestedAttribute{
+			"otlp": schema.SingleNestedAttribute{
 				MarkdownDescription: "Export metrics to an OTLP/HTTP endpoint you own.",
 				Optional:            true,
 				Attributes: map[string]schema.Attribute{
@@ -112,8 +112,8 @@ func (m *customerVectorAggregatorModel) toProto() *serverv1.CustomerVectorAggreg
 		return nil
 	}
 	return &serverv1.CustomerVectorAggregatorConfig{
-		DatadogExport:     m.DatadogExport.toProto(),
-		OtlpMetricsExport: m.OtlpMetricsExport.toProto(),
+		DatadogExport:     m.Datadog.toProto(),
+		OtlpMetricsExport: m.Otlp.toProto(),
 	}
 }
 
@@ -199,13 +199,13 @@ func customerVectorAggregatorFromProto(p *serverv1.CustomerVectorAggregatorConfi
 		return nil
 	}
 	m := &customerVectorAggregatorModel{}
-	if prior.DatadogExport != nil {
-		m.DatadogExport = customerDatadogExportFromProto(p.GetDatadogExport())
+	if prior.Datadog != nil {
+		m.Datadog = customerDatadogExportFromProto(p.GetDatadogExport())
 	}
-	if prior.OtlpMetricsExport != nil {
-		m.OtlpMetricsExport = customerOtlpMetricsExportFromProto(p.GetOtlpMetricsExport())
+	if prior.Otlp != nil {
+		m.Otlp = customerOtlpMetricsExportFromProto(p.GetOtlpMetricsExport())
 	}
-	if m.DatadogExport == nil && m.OtlpMetricsExport == nil {
+	if m.Datadog == nil && m.Otlp == nil {
 		return nil
 	}
 	return m

--- a/internal/provider/telemetry_resource.go
+++ b/internal/provider/telemetry_resource.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 )
 
@@ -427,13 +426,7 @@ func buildTelemetryUpdateMask(data, state *TelemetryResourceModel) []string {
 	if !data.AggregatorSpec.IsUnknown() && !data.AggregatorSpec.Equal(state.AggregatorSpec) {
 		paths = append(paths, "aggregator")
 	}
-	// Mask the exporters, not the parent: unmodelled siblings like replicas live there too.
-	if !proto.Equal(data.CustomerVectorAggregator.toProto(), state.CustomerVectorAggregator.toProto()) {
-		paths = append(paths,
-			"customer_vector_aggregator.datadog_export",
-			"customer_vector_aggregator.otlp_metrics_export",
-		)
-	}
+	paths = append(paths, customerVectorAggregatorMaskPaths(data.CustomerVectorAggregator, state.CustomerVectorAggregator)...)
 	return paths
 }
 

--- a/internal/provider/telemetry_resource.go
+++ b/internal/provider/telemetry_resource.go
@@ -427,8 +427,7 @@ func buildTelemetryUpdateMask(data, state *TelemetryResourceModel) []string {
 	if !data.AggregatorSpec.IsUnknown() && !data.AggregatorSpec.Equal(state.AggregatorSpec) {
 		paths = append(paths, "aggregator")
 	}
-	// Mask the exporters, not their parent: other surfaces set replicas, statsd_export
-	// and the remap VRL on that same message, and a parent path would clear them.
+	// Mask the exporters, not the parent: unmodelled siblings like replicas live there too.
 	if !proto.Equal(data.CustomerVectorAggregator.toProto(), state.CustomerVectorAggregator.toProto()) {
 		paths = append(paths,
 			"customer_vector_aggregator.datadog_export",

--- a/internal/provider/telemetry_resource.go
+++ b/internal/provider/telemetry_resource.go
@@ -90,7 +90,7 @@ type TelemetryResourceModel struct {
 	OtelCollectorSpec        types.Object                   `tfsdk:"otel_collector_spec"`
 	ClickhouseDeploymentSpec types.Object                   `tfsdk:"clickhouse_deployment_spec"`
 	AggregatorSpec           types.Object                   `tfsdk:"aggregator_spec"`
-	CustomerVectorAggregator *customerVectorAggregatorModel `tfsdk:"customer_vector_aggregator"`
+	Exporters                *customerVectorAggregatorModel `tfsdk:"exporters"`
 }
 
 func (r *TelemetryResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -246,7 +246,7 @@ func (r *TelemetryResource) Schema(ctx context.Context, req resource.SchemaReque
 					objectplanmodifier.UseStateForUnknown(),
 				},
 			},
-			"customer_vector_aggregator": customerVectorAggregatorSchema(),
+			"exporters": customerVectorAggregatorSchema(),
 		},
 	}
 }
@@ -274,7 +274,7 @@ func (r *TelemetryResource) Configure(ctx context.Context, req resource.Configur
 func buildTelemetryDeploymentSpec(ctx context.Context, data *TelemetryResourceModel, diags *diag.Diagnostics) *serverv1.TelemetryDeploymentSpec {
 	spec := &serverv1.TelemetryDeploymentSpec{
 		Namespace:                data.Namespace.ValueStringPointer(),
-		CustomerVectorAggregator: data.CustomerVectorAggregator.toProto(),
+		CustomerVectorAggregator: data.Exporters.toProto(),
 	}
 
 	if !data.ClickhouseDeploymentSpec.IsNull() && !data.ClickhouseDeploymentSpec.IsUnknown() {
@@ -372,7 +372,7 @@ func updateStateFromTelemetrySpec(data *TelemetryResourceModel, spec *serverv1.T
 	}
 
 	data.Namespace = types.StringPointerValue(spec.Namespace)
-	data.CustomerVectorAggregator = customerVectorAggregatorFromProto(spec.CustomerVectorAggregator, data.CustomerVectorAggregator)
+	data.Exporters = customerVectorAggregatorFromProto(spec.CustomerVectorAggregator, data.Exporters)
 
 	if spec.ClickHouse != nil {
 		ch := spec.ClickHouse
@@ -426,7 +426,7 @@ func buildTelemetryUpdateMask(data, state *TelemetryResourceModel) []string {
 	if !data.AggregatorSpec.IsUnknown() && !data.AggregatorSpec.Equal(state.AggregatorSpec) {
 		paths = append(paths, "aggregator")
 	}
-	paths = append(paths, customerVectorAggregatorMaskPaths(data.CustomerVectorAggregator, state.CustomerVectorAggregator)...)
+	paths = append(paths, customerVectorAggregatorMaskPaths(data.Exporters, state.Exporters)...)
 	return paths
 }
 

--- a/internal/provider/telemetry_resource.go
+++ b/internal/provider/telemetry_resource.go
@@ -372,7 +372,7 @@ func updateStateFromTelemetrySpec(data *TelemetryResourceModel, spec *serverv1.T
 	}
 
 	data.Namespace = types.StringPointerValue(spec.Namespace)
-	data.CustomerVectorAggregator = customerVectorAggregatorFromProto(spec.CustomerVectorAggregator)
+	data.CustomerVectorAggregator = customerVectorAggregatorFromProto(spec.CustomerVectorAggregator, data.CustomerVectorAggregator)
 
 	if spec.ClickHouse != nil {
 		ch := spec.ClickHouse

--- a/internal/provider/telemetry_resource.go
+++ b/internal/provider/telemetry_resource.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 )
 
@@ -84,12 +85,13 @@ type AggregatorSpecModel struct {
 }
 
 type TelemetryResourceModel struct {
-	Id                       types.String `tfsdk:"id"`
-	Namespace                types.String `tfsdk:"namespace"`
-	KubeClusterId            types.String `tfsdk:"kube_cluster_id"`
-	OtelCollectorSpec        types.Object `tfsdk:"otel_collector_spec"`
-	ClickhouseDeploymentSpec types.Object `tfsdk:"clickhouse_deployment_spec"`
-	AggregatorSpec           types.Object `tfsdk:"aggregator_spec"`
+	Id                       types.String                   `tfsdk:"id"`
+	Namespace                types.String                   `tfsdk:"namespace"`
+	KubeClusterId            types.String                   `tfsdk:"kube_cluster_id"`
+	OtelCollectorSpec        types.Object                   `tfsdk:"otel_collector_spec"`
+	ClickhouseDeploymentSpec types.Object                   `tfsdk:"clickhouse_deployment_spec"`
+	AggregatorSpec           types.Object                   `tfsdk:"aggregator_spec"`
+	CustomerVectorAggregator *customerVectorAggregatorModel `tfsdk:"customer_vector_aggregator"`
 }
 
 func (r *TelemetryResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -245,6 +247,7 @@ func (r *TelemetryResource) Schema(ctx context.Context, req resource.SchemaReque
 					objectplanmodifier.UseStateForUnknown(),
 				},
 			},
+			"customer_vector_aggregator": customerVectorAggregatorSchema(),
 		},
 	}
 }
@@ -271,7 +274,8 @@ func (r *TelemetryResource) Configure(ctx context.Context, req resource.Configur
 // buildTelemetryDeploymentSpec builds a TelemetryDeploymentSpec proto from a Terraform model.
 func buildTelemetryDeploymentSpec(ctx context.Context, data *TelemetryResourceModel, diags *diag.Diagnostics) *serverv1.TelemetryDeploymentSpec {
 	spec := &serverv1.TelemetryDeploymentSpec{
-		Namespace: data.Namespace.ValueStringPointer(),
+		Namespace:                data.Namespace.ValueStringPointer(),
+		CustomerVectorAggregator: data.CustomerVectorAggregator.toProto(),
 	}
 
 	if !data.ClickhouseDeploymentSpec.IsNull() && !data.ClickhouseDeploymentSpec.IsUnknown() {
@@ -369,6 +373,7 @@ func updateStateFromTelemetrySpec(data *TelemetryResourceModel, spec *serverv1.T
 	}
 
 	data.Namespace = types.StringPointerValue(spec.Namespace)
+	data.CustomerVectorAggregator = customerVectorAggregatorFromProto(spec.CustomerVectorAggregator)
 
 	if spec.ClickHouse != nil {
 		ch := spec.ClickHouse
@@ -421,6 +426,14 @@ func buildTelemetryUpdateMask(data, state *TelemetryResourceModel) []string {
 	}
 	if !data.AggregatorSpec.IsUnknown() && !data.AggregatorSpec.Equal(state.AggregatorSpec) {
 		paths = append(paths, "aggregator")
+	}
+	// Mask the exporters, not their parent: other surfaces set replicas, statsd_export
+	// and the remap VRL on that same message, and a parent path would clear them.
+	if !proto.Equal(data.CustomerVectorAggregator.toProto(), state.CustomerVectorAggregator.toProto()) {
+		paths = append(paths,
+			"customer_vector_aggregator.datadog_export",
+			"customer_vector_aggregator.otlp_metrics_export",
+		)
 	}
 	return paths
 }

--- a/internal/provider/telemetry_resource_test.go
+++ b/internal/provider/telemetry_resource_test.go
@@ -483,3 +483,161 @@ resource "chalk_telemetry" "test" {
 		},
 	})
 }
+
+// TestTelemetryResourceCustomerVectorAggregator verifies both exporters round-trip and
+// that a signal's presence, not its value, is what the server sees as "export this".
+func TestTelemetryResourceCustomerVectorAggregator(t *testing.T) {
+	t.Parallel()
+	server := setupMockBuilderServerTelemetry(t)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig(server.URL) + `
+resource "chalk_telemetry" "test" {
+  kube_cluster_id = "test-cluster-id"
+  customer_vector_aggregator = {
+    datadog_export = {
+      api_key_secret_reference = "arn:aws:secretsmanager:us-west-2:123456789012:secret:dd-abc123"
+      api_host                 = "datadoghq.eu"
+      logs                     = { enabled = true }
+      traces                   = {}
+      metrics                  = { enabled = false }
+    }
+    otlp_metrics_export = {
+      url                                   = "https://otlp.example.com/v1/metrics"
+      authorization_header_secret_reference = "arn:aws:secretsmanager:us-west-2:123456789012:secret:otlp-def456"
+    }
+  }
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("chalk_telemetry.test", "customer_vector_aggregator.datadog_export.api_host", "datadoghq.eu"),
+					resource.TestCheckResourceAttr("chalk_telemetry.test", "customer_vector_aggregator.datadog_export.logs.enabled", "true"),
+					resource.TestCheckResourceAttr("chalk_telemetry.test", "customer_vector_aggregator.otlp_metrics_export.url", "https://otlp.example.com/v1/metrics"),
+					func(s *terraform.State) error {
+						captured := server.GetCapturedRequests("CreateTelemetryDeployment")
+						require.Len(t, captured, 1, "Expected exactly one CreateTelemetryDeployment call")
+
+						req := captured[0].(*serverv1.CreateTelemetryDeploymentRequest)
+						agg := req.Spec.GetCustomerVectorAggregator()
+						require.NotNil(t, agg)
+
+						dd := agg.GetDatadogExport()
+						require.NotNil(t, dd)
+						assert.Equal(t, "arn:aws:secretsmanager:us-west-2:123456789012:secret:dd-abc123", dd.GetApiKeySecretArn())
+						assert.Equal(t, "datadoghq.eu", dd.GetApiHost())
+
+						require.NotNil(t, dd.GetLogs())
+						assert.Equal(t, true, dd.GetLogs().GetEnabled())
+						// An empty block must still send a message: the server reads presence as
+						// enabled, and a nil traces field would silently drop trace export.
+						require.NotNil(t, dd.GetTraces())
+						assert.Nil(t, dd.GetTraces().Enabled)
+						require.NotNil(t, dd.GetMetrics())
+						assert.Equal(t, false, dd.GetMetrics().GetEnabled())
+
+						otlp := agg.GetOtlpMetricsExport()
+						require.NotNil(t, otlp)
+						assert.Equal(t, "https://otlp.example.com/v1/metrics", otlp.GetUrl())
+						assert.Equal(t, "arn:aws:secretsmanager:us-west-2:123456789012:secret:otlp-def456", otlp.GetAuthorizationHeaderSecretArn())
+
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+// TestTelemetryResourceCustomerVectorAggregatorFieldMask verifies the mask names the two
+// exporters rather than their parent, so unmanaged siblings on that message survive.
+func TestTelemetryResourceCustomerVectorAggregatorFieldMask(t *testing.T) {
+	t.Parallel()
+	server := setupMockBuilderServerTelemetry(t)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig(server.URL) + `
+resource "chalk_telemetry" "test" {
+  kube_cluster_id = "test-cluster-id"
+  customer_vector_aggregator = {
+    datadog_export = {
+      api_key_secret_reference = "arn:aws:secretsmanager:us-west-2:123456789012:secret:dd-abc123"
+      logs                     = { enabled = true }
+    }
+  }
+}
+`,
+			},
+			{
+				Config: providerConfig(server.URL) + `
+resource "chalk_telemetry" "test" {
+  kube_cluster_id = "test-cluster-id"
+  customer_vector_aggregator = {
+    datadog_export = {
+      api_key_secret_reference = "arn:aws:secretsmanager:us-west-2:123456789012:secret:dd-abc123"
+      logs                     = { enabled = false }
+    }
+  }
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					func(s *terraform.State) error {
+						captured := server.GetCapturedRequests("UpdateTelemetryDeployment")
+						require.NotEmpty(t, captured, "Expected at least one UpdateTelemetryDeployment call")
+
+						req := captured[len(captured)-1].(*serverv1.UpdateTelemetryDeploymentRequest)
+						require.NotNil(t, req.UpdateMask)
+						assert.Equal(t, []string{
+							"customer_vector_aggregator.datadog_export",
+							"customer_vector_aggregator.otlp_metrics_export",
+						}, req.UpdateMask.Paths)
+
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+// TestTelemetryResourceCustomerVectorAggregatorOmitted verifies that a deployment carrying
+// only fields this resource does not model reads back as unset instead of drifting.
+func TestTelemetryResourceCustomerVectorAggregatorOmitted(t *testing.T) {
+	t.Parallel()
+	server := setupMockBuilderServerTelemetry(t)
+
+	server.OnGetTelemetryDeployment().WithBehavior(func(req proto.Message) (proto.Message, error) {
+		return &serverv1.GetTelemetryDeploymentResponse{
+			Deployment: &serverv1.TelemetryDeployment{
+				Id:        "test-telemetry-id",
+				ClusterId: "test-cluster-id",
+				Spec: &serverv1.TelemetryDeploymentSpec{
+					CustomerVectorAggregator: &serverv1.CustomerVectorAggregatorConfig{
+						Replicas: proto.Int32(3),
+					},
+				},
+			},
+		}, nil
+	})
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig(server.URL) + `
+resource "chalk_telemetry" "test" {
+  kube_cluster_id = "test-cluster-id"
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr("chalk_telemetry.test", "customer_vector_aggregator.datadog_export"),
+				),
+			},
+		},
+	})
+}

--- a/internal/provider/telemetry_resource_test.go
+++ b/internal/provider/telemetry_resource_test.go
@@ -484,7 +484,7 @@ resource "chalk_telemetry" "test" {
 	})
 }
 
-// TestTelemetryResourceCustomerVectorAggregator verifies both exporters round-trip and that presence enables a signal.
+// TestTelemetryResourceCustomerVectorAggregator verifies both exporters round-trip faithfully.
 func TestTelemetryResourceCustomerVectorAggregator(t *testing.T) {
 	t.Parallel()
 	server := setupMockBuilderServerTelemetry(t)
@@ -530,7 +530,7 @@ resource "chalk_telemetry" "test" {
 
 						require.NotNil(t, dd.GetLogs())
 						assert.Equal(t, true, dd.GetLogs().GetEnabled())
-						// A nil traces field would silently drop trace export; presence is the opt-in.
+						// An empty block must round-trip as a present message with enabled unset.
 						require.NotNil(t, dd.GetTraces())
 						assert.Nil(t, dd.GetTraces().Enabled)
 						require.NotNil(t, dd.GetMetrics())

--- a/internal/provider/telemetry_resource_test.go
+++ b/internal/provider/telemetry_resource_test.go
@@ -484,8 +484,7 @@ resource "chalk_telemetry" "test" {
 	})
 }
 
-// TestTelemetryResourceCustomerVectorAggregator verifies both exporters round-trip and
-// that a signal's presence, not its value, is what the server sees as "export this".
+// TestTelemetryResourceCustomerVectorAggregator verifies both exporters round-trip and that presence enables a signal.
 func TestTelemetryResourceCustomerVectorAggregator(t *testing.T) {
 	t.Parallel()
 	server := setupMockBuilderServerTelemetry(t)
@@ -531,8 +530,7 @@ resource "chalk_telemetry" "test" {
 
 						require.NotNil(t, dd.GetLogs())
 						assert.Equal(t, true, dd.GetLogs().GetEnabled())
-						// An empty block must still send a message: the server reads presence as
-						// enabled, and a nil traces field would silently drop trace export.
+						// A nil traces field would silently drop trace export; presence is the opt-in.
 						require.NotNil(t, dd.GetTraces())
 						assert.Nil(t, dd.GetTraces().Enabled)
 						require.NotNil(t, dd.GetMetrics())
@@ -551,8 +549,7 @@ resource "chalk_telemetry" "test" {
 	})
 }
 
-// TestTelemetryResourceCustomerVectorAggregatorFieldMask verifies the mask names the two
-// exporters rather than their parent, so unmanaged siblings on that message survive.
+// TestTelemetryResourceCustomerVectorAggregatorFieldMask verifies the mask names the exporters, not their parent.
 func TestTelemetryResourceCustomerVectorAggregatorFieldMask(t *testing.T) {
 	t.Parallel()
 	server := setupMockBuilderServerTelemetry(t)
@@ -605,8 +602,7 @@ resource "chalk_telemetry" "test" {
 	})
 }
 
-// TestTelemetryResourceCustomerVectorAggregatorOmitted verifies that a deployment carrying
-// only fields this resource does not model reads back as unset instead of drifting.
+// TestTelemetryResourceCustomerVectorAggregatorOmitted verifies an unmodelled-only config reads back as unset.
 func TestTelemetryResourceCustomerVectorAggregatorOmitted(t *testing.T) {
 	t.Parallel()
 	server := setupMockBuilderServerTelemetry(t)

--- a/internal/provider/telemetry_resource_test.go
+++ b/internal/provider/telemetry_resource_test.go
@@ -496,15 +496,15 @@ func TestTelemetryResourceCustomerVectorAggregator(t *testing.T) {
 				Config: providerConfig(server.URL) + `
 resource "chalk_telemetry" "test" {
   kube_cluster_id = "test-cluster-id"
-  customer_vector_aggregator = {
-    datadog_export = {
+  exporters = {
+    datadog = {
       api_key_secret_reference = "arn:aws:secretsmanager:us-west-2:123456789012:secret:dd-abc123"
       api_host                 = "datadoghq.eu"
       logs                     = { enabled = true }
       traces                   = {}
       metrics                  = { enabled = false }
     }
-    otlp_metrics_export = {
+    otlp = {
       url                                   = "https://otlp.example.com/v1/metrics"
       authorization_header_secret_reference = "arn:aws:secretsmanager:us-west-2:123456789012:secret:otlp-def456"
     }
@@ -512,9 +512,9 @@ resource "chalk_telemetry" "test" {
 }
 `,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("chalk_telemetry.test", "customer_vector_aggregator.datadog_export.api_host", "datadoghq.eu"),
-					resource.TestCheckResourceAttr("chalk_telemetry.test", "customer_vector_aggregator.datadog_export.logs.enabled", "true"),
-					resource.TestCheckResourceAttr("chalk_telemetry.test", "customer_vector_aggregator.otlp_metrics_export.url", "https://otlp.example.com/v1/metrics"),
+					resource.TestCheckResourceAttr("chalk_telemetry.test", "exporters.datadog.api_host", "datadoghq.eu"),
+					resource.TestCheckResourceAttr("chalk_telemetry.test", "exporters.datadog.logs.enabled", "true"),
+					resource.TestCheckResourceAttr("chalk_telemetry.test", "exporters.otlp.url", "https://otlp.example.com/v1/metrics"),
 					func(s *terraform.State) error {
 						captured := server.GetCapturedRequests("CreateTelemetryDeployment")
 						require.Len(t, captured, 1, "Expected exactly one CreateTelemetryDeployment call")
@@ -562,12 +562,12 @@ func TestTelemetryResourceCustomerVectorAggregatorFieldMask(t *testing.T) {
 				Config: providerConfig(server.URL) + `
 resource "chalk_telemetry" "test" {
   kube_cluster_id = "test-cluster-id"
-  customer_vector_aggregator = {
-    datadog_export = {
+  exporters = {
+    datadog = {
       api_key_secret_reference = "arn:aws:secretsmanager:us-west-2:123456789012:secret:dd-abc123"
       logs                     = { enabled = true }
     }
-    otlp_metrics_export = {
+    otlp = {
       url = "https://otlp.example.com/v1/metrics"
     }
   }
@@ -578,12 +578,12 @@ resource "chalk_telemetry" "test" {
 				Config: providerConfig(server.URL) + `
 resource "chalk_telemetry" "test" {
   kube_cluster_id = "test-cluster-id"
-  customer_vector_aggregator = {
-    datadog_export = {
+  exporters = {
+    datadog = {
       api_key_secret_reference = "arn:aws:secretsmanager:us-west-2:123456789012:secret:dd-abc123"
       logs                     = { enabled = false }
     }
-    otlp_metrics_export = {
+    otlp = {
       url = "https://otlp.example.com/v1/metrics"
     }
   }
@@ -625,7 +625,7 @@ func TestTelemetryResourceCustomerVectorAggregatorEmptyBlock(t *testing.T) {
 				Config: providerConfig(server.URL) + `
 resource "chalk_telemetry" "test" {
   kube_cluster_id            = "test-cluster-id"
-  customer_vector_aggregator = {}
+  exporters = {}
 }
 `,
 				ExpectError: regexp.MustCompile("At least one attribute"),
@@ -667,7 +667,7 @@ resource "chalk_telemetry" "test" {
 }
 `,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckNoResourceAttr("chalk_telemetry.test", "customer_vector_aggregator.datadog_export"),
+					resource.TestCheckNoResourceAttr("chalk_telemetry.test", "exporters.datadog"),
 				),
 			},
 		},
@@ -707,16 +707,16 @@ func TestTelemetryResourceCustomerVectorAggregatorUnownedExporter(t *testing.T) 
 				Config: providerConfig(server.URL) + `
 resource "chalk_telemetry" "test" {
   kube_cluster_id = "test-cluster-id"
-  customer_vector_aggregator = {
-    otlp_metrics_export = {
+  exporters = {
+    otlp = {
       url = "https://otlp.example.com/v1/metrics"
     }
   }
 }
 `,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("chalk_telemetry.test", "customer_vector_aggregator.otlp_metrics_export.url", "https://otlp.example.com/v1/metrics"),
-					resource.TestCheckNoResourceAttr("chalk_telemetry.test", "customer_vector_aggregator.datadog_export"),
+					resource.TestCheckResourceAttr("chalk_telemetry.test", "exporters.otlp.url", "https://otlp.example.com/v1/metrics"),
+					resource.TestCheckNoResourceAttr("chalk_telemetry.test", "exporters.datadog"),
 				),
 			},
 		},

--- a/internal/provider/telemetry_resource_test.go
+++ b/internal/provider/telemetry_resource_test.go
@@ -634,7 +634,8 @@ resource "chalk_telemetry" "test" {
 	})
 }
 
-// TestTelemetryResourceCustomerVectorAggregatorOmitted verifies an unmodelled-only config reads back as unset.
+// TestTelemetryResourceCustomerVectorAggregatorOmitted verifies exporters configured
+// outside Terraform are not adopted into state and planned away.
 func TestTelemetryResourceCustomerVectorAggregatorOmitted(t *testing.T) {
 	t.Parallel()
 	server := setupMockBuilderServerTelemetry(t)
@@ -647,6 +648,9 @@ func TestTelemetryResourceCustomerVectorAggregatorOmitted(t *testing.T) {
 				Spec: &serverv1.TelemetryDeploymentSpec{
 					CustomerVectorAggregator: &serverv1.CustomerVectorAggregatorConfig{
 						Replicas: proto.Int32(3),
+						OtlpMetricsExport: &serverv1.CustomerVectorAggregatorOtlpMetricsExportConfig{
+							Url: "https://external.example.com/v1/metrics",
+						},
 					},
 				},
 			},
@@ -663,6 +667,55 @@ resource "chalk_telemetry" "test" {
 }
 `,
 				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr("chalk_telemetry.test", "customer_vector_aggregator.datadog_export"),
+				),
+			},
+		},
+	})
+}
+
+// TestTelemetryResourceCustomerVectorAggregatorUnownedExporter verifies owning one exporter
+// does not adopt the other when another client configures it.
+func TestTelemetryResourceCustomerVectorAggregatorUnownedExporter(t *testing.T) {
+	t.Parallel()
+	server := testserver.NewMockBuilderServer(t)
+	t.Cleanup(func() { server.Close() })
+
+	var currentSpec *serverv1.TelemetryDeploymentSpec
+	server.OnCreateTelemetryDeployment().WithBehavior(func(req proto.Message) (proto.Message, error) {
+		currentSpec = req.(*serverv1.CreateTelemetryDeploymentRequest).Spec
+		return &serverv1.CreateTelemetryDeploymentResponse{TelemetryDeploymentId: "test-telemetry-id"}, nil
+	})
+	server.OnGetTelemetryDeployment().WithBehavior(func(req proto.Message) (proto.Message, error) {
+		spec := proto.Clone(currentSpec).(*serverv1.TelemetryDeploymentSpec)
+		spec.CustomerVectorAggregator.DatadogExport = &serverv1.CustomerVectorAggregatorDatadogExportConfig{
+			ApiKeySource: &serverv1.CustomerVectorAggregatorDatadogExportConfig_ApiKeySecretArn{
+				ApiKeySecretArn: "arn:aws:secretsmanager:us-west-2:123456789012:secret:dashboard-dd",
+			},
+			Logs: &serverv1.CustomerVectorAggregatorDatadogSignalExportSpec{},
+		}
+		return &serverv1.GetTelemetryDeploymentResponse{
+			Deployment: &serverv1.TelemetryDeployment{Id: "test-telemetry-id", ClusterId: "test-cluster-id", Spec: spec},
+		}, nil
+	})
+	server.OnDeleteTelemetryDeployment().Return(&serverv1.DeleteTelemetryDeploymentResponse{})
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig(server.URL) + `
+resource "chalk_telemetry" "test" {
+  kube_cluster_id = "test-cluster-id"
+  customer_vector_aggregator = {
+    otlp_metrics_export = {
+      url = "https://otlp.example.com/v1/metrics"
+    }
+  }
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("chalk_telemetry.test", "customer_vector_aggregator.otlp_metrics_export.url", "https://otlp.example.com/v1/metrics"),
 					resource.TestCheckNoResourceAttr("chalk_telemetry.test", "customer_vector_aggregator.datadog_export"),
 				),
 			},

--- a/internal/provider/telemetry_resource_test.go
+++ b/internal/provider/telemetry_resource_test.go
@@ -549,7 +549,8 @@ resource "chalk_telemetry" "test" {
 	})
 }
 
-// TestTelemetryResourceCustomerVectorAggregatorFieldMask verifies the mask names the exporters, not their parent.
+// TestTelemetryResourceCustomerVectorAggregatorFieldMask verifies the mask names only owned
+// leaves of the changed exporter, so unmodelled fields and the unchanged exporter survive.
 func TestTelemetryResourceCustomerVectorAggregatorFieldMask(t *testing.T) {
 	t.Parallel()
 	server := setupMockBuilderServerTelemetry(t)
@@ -566,6 +567,9 @@ resource "chalk_telemetry" "test" {
       api_key_secret_reference = "arn:aws:secretsmanager:us-west-2:123456789012:secret:dd-abc123"
       logs                     = { enabled = true }
     }
+    otlp_metrics_export = {
+      url = "https://otlp.example.com/v1/metrics"
+    }
   }
 }
 `,
@@ -579,6 +583,9 @@ resource "chalk_telemetry" "test" {
       api_key_secret_reference = "arn:aws:secretsmanager:us-west-2:123456789012:secret:dd-abc123"
       logs                     = { enabled = false }
     }
+    otlp_metrics_export = {
+      url = "https://otlp.example.com/v1/metrics"
+    }
   }
 }
 `,
@@ -590,13 +597,38 @@ resource "chalk_telemetry" "test" {
 						req := captured[len(captured)-1].(*serverv1.UpdateTelemetryDeploymentRequest)
 						require.NotNil(t, req.UpdateMask)
 						assert.Equal(t, []string{
-							"customer_vector_aggregator.datadog_export",
-							"customer_vector_aggregator.otlp_metrics_export",
+							"customer_vector_aggregator.datadog_export.api_key_secret_arn",
+							"customer_vector_aggregator.datadog_export.api_host",
+							"customer_vector_aggregator.datadog_export.logs.enabled",
+							"customer_vector_aggregator.datadog_export.traces",
+							"customer_vector_aggregator.datadog_export.metrics",
 						}, req.UpdateMask.Paths)
 
 						return nil
 					},
 				),
+			},
+		},
+	})
+}
+
+// TestTelemetryResourceCustomerVectorAggregatorEmptyBlock verifies an empty block is
+// rejected up front; it would otherwise drift forever since state reads it back as unset.
+func TestTelemetryResourceCustomerVectorAggregatorEmptyBlock(t *testing.T) {
+	t.Parallel()
+	server := setupMockBuilderServerTelemetry(t)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig(server.URL) + `
+resource "chalk_telemetry" "test" {
+  kube_cluster_id            = "test-cluster-id"
+  customer_vector_aggregator = {}
+}
+`,
+				ExpectError: regexp.MustCompile("At least one attribute"),
 			},
 		},
 	})


### PR DESCRIPTION
Closes [SUP-49](https://linear.app/chalk-ai/issue/SUP-49/make-customer-aggregator-configurable-through-terraform).

Adds an `exporters` attribute to `chalk_telemetry` with `datadog` and `otlp` blocks, mapping to `TelemetryDeploymentSpec.customer_vector_aggregator`. No server changes needed beyond the default flip below.

```hcl
exporters = {
  datadog = {
    api_key_secret_reference = "arn:aws:secretsmanager:...:secret:datadog-api-key"
    metrics = { enabled = false }   # logs/traces/metrics export by default
  }
  otlp = {
    url = "https://otlp.example.com/v1/metrics"
  }
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)