### PR TITLE
Regenerate changelog for chalk_telemetry exporters

### DIFF
--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -11,4 +11,19 @@ For migration guidance and non-schema changes, see the [project changelog](https
 
 ## Unreleased
 
-No schema or permission changes.
+### Resources
+
+- Added attribute `chalk_telemetry.exporters` (`object`).
+- Added attribute `chalk_telemetry.exporters.datadog` (`object`).
+- Added attribute `chalk_telemetry.exporters.datadog.api_host` (`string`).
+- Added attribute `chalk_telemetry.exporters.datadog.api_key_secret_reference` (`string`).
+- Added attribute `chalk_telemetry.exporters.datadog.logs` (`object`).
+- Added attribute `chalk_telemetry.exporters.datadog.logs.enabled` (`bool`).
+- Added attribute `chalk_telemetry.exporters.datadog.metrics` (`object`).
+- Added attribute `chalk_telemetry.exporters.datadog.metrics.enabled` (`bool`).
+- Added attribute `chalk_telemetry.exporters.datadog.traces` (`object`).
+- Added attribute `chalk_telemetry.exporters.datadog.traces.enabled` (`bool`).
+- Added attribute `chalk_telemetry.exporters.otlp` (`object`).
+- Added attribute `chalk_telemetry.exporters.otlp.authorization_header_secret_reference` (`string`).
+- Added attribute `chalk_telemetry.exporters.otlp.enabled` (`bool`).
+- Added attribute `chalk_telemetry.exporters.otlp.url` (`string`).


### PR DESCRIPTION
Fixes the docs-drift failure on main ([build 220](https://buildkite.com/chalk/terraform-provider-chalk-pr/builds/220)): #99 (changelog generator) and #101 (telemetry exporters) merged independently, each doc-clean, but the combination leaves the generated `docs/guides/changelog.md` stale. Regenerated via `make docs`, no hand edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)