### PR TITLE
Restore designator on cloud component resources (INF-1851)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+NOTES:
+
+* Restore the read-only `designator` attribute on `chalk_managed_cloud_storage`, `chalk_unmanaged_cloud_storage`, `chalk_managed_container_registry`, `chalk_unmanaged_container_registry`, `chalk_managed_cluster`, `chalk_managed_aws_vpc`, and `chalk_managed_gcp_vpc`. The server generates it and it cannot be derived, and it appears in managed cluster DNS zones, so it must be readable from Terraform.
+
 ## 1.1.0
 
 NOTES:

--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -13,6 +13,11 @@ For migration guidance and non-schema changes, see the [project changelog](https
 
 ### Resources
 
+- Added attribute `chalk_managed_aws_vpc.designator` (`string`).
+- Added attribute `chalk_managed_cloud_storage.designator` (`string`).
+- Added attribute `chalk_managed_cluster.designator` (`string`).
+- Added attribute `chalk_managed_container_registry.designator` (`string`).
+- Added attribute `chalk_managed_gcp_vpc.designator` (`string`).
 - Added attribute `chalk_telemetry.exporters` (`object`).
 - Added attribute `chalk_telemetry.exporters.datadog` (`object`).
 - Added attribute `chalk_telemetry.exporters.datadog.api_host` (`string`).
@@ -27,3 +32,5 @@ For migration guidance and non-schema changes, see the [project changelog](https
 - Added attribute `chalk_telemetry.exporters.otlp.authorization_header_secret_reference` (`string`).
 - Added attribute `chalk_telemetry.exporters.otlp.enabled` (`bool`).
 - Added attribute `chalk_telemetry.exporters.otlp.url` (`string`).
+- Added attribute `chalk_unmanaged_cloud_storage.designator` (`string`).
+- Added attribute `chalk_unmanaged_container_registry.designator` (`string`).

--- a/docs/resources/managed_aws_vpc.md
+++ b/docs/resources/managed_aws_vpc.md
@@ -32,6 +32,7 @@ Chalk managed AWS VPC resource. Creates a fully managed VPC using the provided c
 
 ### Read-Only
 
+- `designator` (String) VPC designator
 - `id` (String) VPC identifier
 
 <a id="nestedatt--subnets"></a>

--- a/docs/resources/managed_cloud_storage.md
+++ b/docs/resources/managed_cloud_storage.md
@@ -44,6 +44,7 @@ resource "chalk_managed_cloud_storage" "datasets" {
 
 ### Read-Only
 
+- `designator` (String) Server-assigned designator. Only populated for managed storages.
 - `id` (String) Cloud storage identifier.
 - `uri` (String) URI of the managed bucket. Derived and set by Chalk.
 

--- a/docs/resources/managed_cluster.md
+++ b/docs/resources/managed_cluster.md
@@ -31,6 +31,7 @@ Chalk managed Kubernetes cluster resource. Creates a fully managed cluster using
 
 ### Read-Only
 
+- `designator` (String) Cluster designator
 - `id` (String) Cluster identifier
 
 <a id="nestedatt--data_plane_controller"></a>

--- a/docs/resources/managed_container_registry.md
+++ b/docs/resources/managed_container_registry.md
@@ -39,6 +39,7 @@ resource "chalk_managed_container_registry" "ecr" {
 
 ### Read-Only
 
+- `designator` (String) Server-assigned designator. Only populated for managed registries.
 - `id` (String) Cloud container registry identifier.
 - `name` (String) Fully-qualified registry path. Derived and set by Chalk.
 

--- a/docs/resources/managed_gcp_vpc.md
+++ b/docs/resources/managed_gcp_vpc.md
@@ -30,6 +30,7 @@ Chalk managed GCP VPC resource. Creates a fully managed VPC using the provided c
 
 ### Read-Only
 
+- `designator` (String) VPC designator
 - `id` (String) VPC identifier
 
 <a id="nestedatt--subnets"></a>

--- a/docs/resources/unmanaged_cloud_storage.md
+++ b/docs/resources/unmanaged_cloud_storage.md
@@ -46,6 +46,7 @@ resource "chalk_unmanaged_cloud_storage" "datasets" {
 
 ### Read-Only
 
+- `designator` (String) Server-assigned designator. Only populated for managed storages.
 - `id` (String) Cloud storage identifier.
 
 ## Import

--- a/docs/resources/unmanaged_container_registry.md
+++ b/docs/resources/unmanaged_container_registry.md
@@ -42,6 +42,7 @@ resource "chalk_unmanaged_container_registry" "gar" {
 
 ### Read-Only
 
+- `designator` (String) Server-assigned designator. Only populated for managed registries.
 - `id` (String) Cloud container registry identifier.
 
 ## Import

--- a/internal/provider/cloud_container_registry_common.go
+++ b/internal/provider/cloud_container_registry_common.go
@@ -20,6 +20,7 @@ type cloudContainerRegistryResourceModel struct {
 	Id                types.String `tfsdk:"id"`
 	Name              types.String `tfsdk:"name"`
 	CloudCredentialId types.String `tfsdk:"cloud_credential_id"`
+	Designator        types.String `tfsdk:"designator"`
 }
 
 // cloudContainerRegistrySchema builds the schema shared by the managed and
@@ -69,6 +70,11 @@ func cloudContainerRegistrySchema(managed bool) schema.Schema {
 				Required:            true,
 				PlanModifiers:       []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
+			"designator": schema.StringAttribute{
+				MarkdownDescription: "Server-assigned designator. Only populated for managed registries.",
+				Computed:            true,
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
 		},
 	}
 }
@@ -85,6 +91,12 @@ func setCloudContainerRegistryState(data *cloudContainerRegistryResourceModel, r
 
 	if registry.CloudCredentialId != nil {
 		data.CloudCredentialId = types.StringValue(registry.GetCloudCredentialId())
+	}
+
+	if registry.Designator != nil {
+		data.Designator = types.StringValue(registry.GetDesignator())
+	} else {
+		data.Designator = types.StringNull()
 	}
 }
 

--- a/internal/provider/cloud_storage_common.go
+++ b/internal/provider/cloud_storage_common.go
@@ -60,6 +60,7 @@ type cloudStorageResourceModel struct {
 	Kind              types.String `tfsdk:"kind"`
 	Uri               types.String `tfsdk:"uri"`
 	CloudCredentialId types.String `tfsdk:"cloud_credential_id"`
+	Designator        types.String `tfsdk:"designator"`
 }
 
 // cloudStorageSchema builds the schema shared by the managed and unmanaged storage
@@ -119,6 +120,11 @@ func cloudStorageSchema(managed bool) schema.Schema {
 				Required:            true,
 				PlanModifiers:       []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
+			"designator": schema.StringAttribute{
+				MarkdownDescription: "Server-assigned designator. Only populated for managed storages.",
+				Computed:            true,
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
 		},
 	}
 }
@@ -142,6 +148,12 @@ func setCloudStorageState(data *cloudStorageResourceModel, storage *serverv1.Clo
 
 	if storage.CloudCredentialId != nil {
 		data.CloudCredentialId = types.StringValue(storage.GetCloudCredentialId())
+	}
+
+	if storage.Designator != nil {
+		data.Designator = types.StringValue(storage.GetDesignator())
+	} else {
+		data.Designator = types.StringNull()
 	}
 }
 

--- a/internal/provider/managed_aws_vpc_resource.go
+++ b/internal/provider/managed_aws_vpc_resource.go
@@ -48,6 +48,7 @@ type ManagedAWSVPCResource struct {
 
 type ManagedAWSVPCResourceModel struct {
 	Id                      types.String `tfsdk:"id"`
+	Designator              types.String `tfsdk:"designator"`
 	CloudCredentialId       types.String `tfsdk:"cloud_credential_id"`
 	CidrBlock               types.String `tfsdk:"cidr_block"`
 	AdditionalCidrBlocks    types.List   `tfsdk:"additional_cidr_blocks"`
@@ -80,6 +81,13 @@ func (r *ManagedAWSVPCResource) Schema(ctx context.Context, req resource.SchemaR
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				MarkdownDescription: "VPC identifier",
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"designator": schema.StringAttribute{
+				MarkdownDescription: "VPC designator",
 				Computed:            true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
@@ -514,6 +522,12 @@ func (r *ManagedAWSVPCResource) updateModelFromProto(ctx context.Context, model 
 	var diags diag.Diagnostics
 
 	model.Id = types.StringValue(vpc.Id)
+
+	if vpc.Designator != nil {
+		model.Designator = types.StringValue(*vpc.Designator)
+	} else {
+		model.Designator = types.StringNull()
+	}
 
 	if vpc.CloudCredentialId != nil {
 		model.CloudCredentialId = types.StringValue(*vpc.CloudCredentialId)

--- a/internal/provider/managed_cluster_resource.go
+++ b/internal/provider/managed_cluster_resource.go
@@ -47,6 +47,7 @@ type ManagedClusterResource struct {
 
 type ManagedClusterResourceModel struct {
 	Id                  types.String              `tfsdk:"id"`
+	Designator          types.String              `tfsdk:"designator"`
 	CloudCredentialId   types.String              `tfsdk:"cloud_credential_id"`
 	VpcId               types.String              `tfsdk:"vpc_id"`
 	MaintenanceWindow   *maintenanceWindowModel   `tfsdk:"maintenance_window"`
@@ -65,6 +66,13 @@ func (r *ManagedClusterResource) Schema(ctx context.Context, req resource.Schema
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				MarkdownDescription: "Cluster identifier",
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"designator": schema.StringAttribute{
+				MarkdownDescription: "Cluster designator",
 				Computed:            true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
@@ -347,6 +355,12 @@ func (r *ManagedClusterResource) waitForClusterActive(
 
 func (r *ManagedClusterResource) updateModelFromProto(model *ManagedClusterResourceModel, cluster *serverv1.CloudComponentClusterResponse) {
 	model.Id = types.StringValue(cluster.Id)
+
+	if cluster.Designator != nil {
+		model.Designator = types.StringValue(*cluster.Designator)
+	} else {
+		model.Designator = types.StringNull()
+	}
 
 	if cluster.CloudCredentialId != nil {
 		model.CloudCredentialId = types.StringValue(*cluster.CloudCredentialId)

--- a/internal/provider/managed_cluster_resource_test.go
+++ b/internal/provider/managed_cluster_resource_test.go
@@ -102,6 +102,7 @@ func clusterResponse(status string, statusErr string) *serverv1.CloudComponentCl
 		Managed:           true,
 		CloudCredentialId: new("cc-test-id"),
 		VpcId:             new("vpc-test-id"),
+		Designator:        new("abcd"),
 		Status:            status,
 		Spec:              &serverv1.CloudComponentCluster{Name: "test-cluster"},
 	}
@@ -170,6 +171,8 @@ func TestManagedClusterResourceCreatePollsUntilActive(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("chalk_managed_cluster.cluster", "id", "cluster-test-id"),
 					resource.TestCheckResourceAttr("chalk_managed_cluster.cluster", "vpc_id", "vpc-test-id"),
+					// The server generates the designator; it must reach state.
+					resource.TestCheckResourceAttr("chalk_managed_cluster.cluster", "designator", "abcd"),
 					// status must not be persisted to state.
 					resource.TestCheckNoResourceAttr("chalk_managed_cluster.cluster", "status"),
 					func(s *terraform.State) error {

--- a/internal/provider/managed_gcp_vpc_resource.go
+++ b/internal/provider/managed_gcp_vpc_resource.go
@@ -32,6 +32,7 @@ type ManagedGCPVPCResource struct {
 
 type ManagedGCPVPCResourceModel struct {
 	Id                types.String `tfsdk:"id"`
+	Designator        types.String `tfsdk:"designator"`
 	CloudCredentialId types.String `tfsdk:"cloud_credential_id"`
 	VpcPeerAddr       types.String `tfsdk:"vpc_peer_addr"`
 	Subnets           types.List   `tfsdk:"subnets"`
@@ -125,6 +126,13 @@ func (r *ManagedGCPVPCResource) Schema(ctx context.Context, req resource.SchemaR
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				MarkdownDescription: "VPC identifier",
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"designator": schema.StringAttribute{
+				MarkdownDescription: "VPC designator",
 				Computed:            true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
@@ -408,6 +416,12 @@ func (r *ManagedGCPVPCResource) updateModelFromProto(ctx context.Context, model 
 	var diags diag.Diagnostics
 
 	model.Id = types.StringValue(vpc.Id)
+
+	if vpc.Designator != nil {
+		model.Designator = types.StringValue(*vpc.Designator)
+	} else {
+		model.Designator = types.StringNull()
+	}
 
 	if vpc.CloudCredentialId != nil {
 		model.CloudCredentialId = types.StringValue(*vpc.CloudCredentialId)


### PR DESCRIPTION
## Summary

Restores the read-only `designator` attribute on the cloud component resources. It was dropped in INF-1703 along with the other computed attributes, but unlike those it is not derivable: the server generates it as a random short id (unique per team), and it appears in real cloud addressing — managed cluster DNS zones are `<designator>.<team>.<visibility>.<provider>.chalk.ai`. Without it in state there is no way to wire up downstream DNS and routing from Terraform.

Restored on all 7 resources that previously exposed it:

- `chalk_managed_cloud_storage`, `chalk_unmanaged_cloud_storage`
- `chalk_managed_container_registry`, `chalk_unmanaged_container_registry`
- `chalk_managed_cluster`
- `chalk_managed_aws_vpc`, `chalk_managed_gcp_vpc`

Same shape as before: `Computed` with `UseStateForUnknown`, populated from the response, null when the server doesn't set it (it is only populated for managed storages/registries). No request payloads change.

The managed cluster create test now asserts the server-generated designator reaches state.

Closes INF-1851.

🤖 Generated with [Claude Code](https://claude.com/claude-code)